### PR TITLE
adds some padding below the title

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -523,7 +523,7 @@ ul li a { -webkit-transition: all .2s ease-in;-moz-transition:all .2s ease-in;-o
 #content article .entry-content table td { text-align: left }
 #content article .meta { color: #999;font-family:"Open Sans";font-weight:100;font-size:1.2em }
 #content article .meta .date { display: inline }
-#content article h1.title { font-family: "Open Sans";font-weight:800;font-size:5em }
+#content article h1.title { font-family: "Open Sans";font-weight:800;font-size:5em;padding-bottom:15px; }
 #content article h1.title a { color: #333;-webkit-transition:color 0.3s;-moz-transition:color 0.3s;-o-transition:color 0.3s;transition:color 0.3s }
 #content div.archives h1.title { font-size: 3em }
 .container .mid-col footer { width: 100% }


### PR DESCRIPTION
Currently the title and the meta information are somewhat attached to each other.
See http://haacked.com/archive/2013/12/03/jekyll-url-extensions/

**Before**
![haacked_before](https://f.cloud.github.com/assets/542458/1671626/7e3af6d6-5cbf-11e3-9b77-cb6827b7d0df.png)

**After**
![haacked_after](https://f.cloud.github.com/assets/542458/1671627/82b77d2e-5cbf-11e3-9c40-5cbfa1a0fd29.png)
