### PR TITLE
Fix h3 text flowing into h2 text

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -348,6 +348,7 @@ article .entry-content table {
     border-collapse: collapse;
     margin-top: 10px;
 }
+article .entry-content h2+h3 { margin-top: 30px; font-size: 22px; }
 article .entry-content table td,
 article .entry-content table th {
     font-family: helvetica, arial, san-serif;


### PR DESCRIPTION
As seen here: http://haacked.com/archive/2014/07/28/github-flow-aliases/ (search for GitHub Flow Aliases).
![github flow like a pro with these 13 git aliases - you_ve been haacked-1](https://cloud.githubusercontent.com/assets/23017/3722531/91345718-166a-11e4-8a25-0f0da0f4e6a3.png)

Also dropped the h3 font size a bit.
