### PR TITLE
Fixed content filter for GitHub Pages

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -1,5 +1,5 @@
 ---
-layout: nil
+layout: null
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
@@ -13,7 +13,7 @@ layout: nil
     <name><![CDATA[{{ site.author | strip_html }}]]></name>
     {% if site.email %}<email><![CDATA[{{ site.email }}]]></email>{% endif %}
   </author>
-  <generator uri="http://octopress.org/">Octopress</generator>
+  <generator uri="https://github.com/">GitHub Pages</generator>
 
   {% for post in site.posts limit: 20 %}
   {% unless post.redirect %}
@@ -22,7 +22,7 @@ layout: nil
     <link href="{{ site.url }}{{ post.url }}"/>
     <updated>{{ post.date | date_to_xmlschema }}</updated>
     <id>{{ site.url }}{{ post.id }}</id>
-    <content type="html"><![CDATA[{{ post.content | expand_urls: site.url | cdata_escape }}]]></content>
+    <content type="html"><![CDATA[{{ post.content | replace:'="/','="http://haacked.com/' | cdata_escape }}]]></content>
   </entry>
   {% endunless %}
   {% endfor %}


### PR DESCRIPTION
- layout:null instead of layout:nil for newer Jekyll.
- Generator update for GHP.
- GHP doesn't support the Liquid "expand_urls" filter so you have to do it manually with "replace".