### PR TITLE
Fix 'seegit' link in 2014-12-03-git-and-github-resources.markdown

### DIFF
--- a/_posts/2014-12-03-git-and-github-resources.markdown
+++ b/_posts/2014-12-03-git-and-github-resources.markdown
@@ -14,7 +14,7 @@ I thought it might be useful to collect some resources that have helped me under
 
 * __[Pro Git](http://git-scm.com/book/en/v2)__ If you have time to read a full book, read this one. It's free!
 * __[The Git Parable](http://tom.preston-werner.com/2009/05/19/the-git-parable.html)__ This story walks through what it would be like to create a Git like system from the gorund up. In the process, you learn a lot about how Git is designed.
-* __[Think like a git](http://think-like-a-git.net/)__ This is for someone who's been using Git, but doesn't feel they really understand it. If you're afraid of the rebase, this is for you. It made Git click for me and inspired me to build [SeeGit](github.com/haacked/seegit).
+* __[Think like a git](http://think-like-a-git.net/)__ This is for someone who's been using Git, but doesn't feel they really understand it. If you're afraid of the rebase, this is for you. It made Git click for me and inspired me to build [SeeGit](https://github.com/haacked/seegit).
 * __[The thing about Git](http://tomayko.com/writings/the-thing-about-git)__ This is a bit of a philosophical piece with practical Git workflow suggestions.
 * __[GitHub Flow Like a Pro with these 13 Git Aliases](http://haacked.com/archive/2014/07/28/github-flow-aliases/)__ This is about Git, but also GitHub workflows. It's a useful collection of aliases I put together.
 


### PR DESCRIPTION
Missing `https://` prefix.
