### PR TITLE
Remove duplicate title tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,7 +7,6 @@
 <head>
 	<meta charset="utf-8">
 	<title>{% if page.title %}{{ page.title }} - {% elsif post.title %}{{ post.title }} - {% endif %}{{ site.title }}</title>
-	<title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
 	<meta name="author" content="{{ site.author }}">
 
 	{% capture description %}


### PR DESCRIPTION
The title tag is duplicated in the default template.