### PR TITLE
Git migrate Blog post draft

### DIFF
--- a/_posts/2015/2015-06-26-git-migrate.markdown
+++ b/_posts/2015/2015-06-26-git-migrate.markdown
@@ -12,7 +12,7 @@ As you may know, a key component of the GitHub Flow workflow is to do all new fe
 
 So what happens when you run into this situation? Are you stuck? Heavens no! [The thing about Git](http://2ndscale.com/rtomayko/2008/the-thing-about-git) is that its very design supports fixing up mistakes after the fact. It's very forgiving in this regard. For example, a recent blog post on the GitHub blog highlights all the different ways [you can undo mistakes in Git](https://github.com/blog/2019-how-to-undo-almost-anything-with-git).
 
-### Fixing up `master`
+### The Easy Case - Fixing `master`
 
 This is the simple case. I made commits on master that were intended for a branch off of master.
 
@@ -102,16 +102,18 @@ As you know, the `git rebase` command is the way you move (well, actually you re
 
 ### Fix up local only branches
 
-The assumption I made in the past two examples is that I'm working with branches that I've pushed to a remote. This makes it easy to find the range of commits that are only on my machine and move those.
+The assumption I made in the past two examples is that I'm working with branches that I've pushed to a remote. That's a convenient scenario because the version of the branch on the server (the remote) is a handy "Save Point" that I can reset to in the form of the remote tracking branch (the ones named `origin/*`).
+
+This makes it easy to find the range of commits that are only on my machine and move those.
 
 But I could be in the situation where I don't have a remote branch. Or maybe the branch I started muddying up already had a local commit.
 
-That's fine, I can just specify a commit range. For example, if I only wanted to move the last two commits on `master` into a new branch, I might do this.
+That's fine, I can just specify a commit range. For example, if I only wanted to move the last commit on `wrong-branch` into a new branch, I might do this.
 
 ```bash
 git branch new-branch
-git reset HEAD~2 --hard
-git checkout new-branch
+git reset HEAD~1 --hard
+git rebase --onto master HEAD~1 new-branch
 ```
 
 ### Alias was a fine TV show, but a better Git technique

--- a/_posts/2015/2015-06-26-git-migrate.markdown
+++ b/_posts/2015/2015-06-26-git-migrate.markdown
@@ -6,33 +6,27 @@ comments: true
 categories: [github git]
 ---
 
-Show of hands if this happens to you. You get excited about an idea and just start writing code and creating commits only to realize you're in the wrong branch. Well, you'll have to tell me about it in the comments because I can't see your hands. This happens to me all the time because I lack impulse control.
+Show of hands if this ever happens to you. After a long day of fighting fires at work, you settle into your favorite chair to unwind and write code. Your fingers fly over the keyboard punctuating your code with semi-colons or paretheses or whatever is appropriate.
 
-As you may know, a key component of the GitHub Flow workflow is to do all new feature work in a branch. Fixing a bug? Create a branch! Adding a new feature? Create a branch! Need to climbe a tree? Well, you get the picture.
+But after a few commits, it dawns on you that you're in the wrong branch. Yeah? Me too. This happens to me all the time because I lack impulse control. You can put your hands down now.
 
-So what happens when you run into this situation? Are you stuck? Heavens no! [The thing about Git](http://2ndscale.com/rtomayko/2008/the-thing-about-git) is that its very design supports fixing up mistakes after the fact. It's very forgiving in this regard. For example, a recent blog post on the GitHub blog highlights all the different ways [you can undo mistakes in Git](https://github.com/blog/2019-how-to-undo-almost-anything-with-git).
+### GitHub Flow
+
+As you may know, a key component of the [GitHub Flow](https://guides.github.com/introduction/flow/) lightweight workflow is to do all new feature work in a branch. Fixing a bug? Create a branch! Adding a new feature? Create a branch! Need to climb a tree? Well, you get the picture.
+
+So what happens when you run into the situation I just described? Are you stuck? Heavens no! [The thing about Git](http://2ndscale.com/rtomayko/2008/the-thing-about-git) is that its very design supports fixing up mistakes after the fact. It's very forgiving in this regard. For example, a recent blog post on the GitHub blog highlights all the different ways [you can undo mistakes in Git](https://github.com/blog/2019-how-to-undo-almost-anything-with-git).
 
 ### The Easy Case - Fixing `master`
 
-This is the simple case. I made commits on master that were intended for a branch off of master.
+This is the simple case. I made commits on master that were intended for a branch off of master. Lets walk through this scenario step by step with some visual aids.
 
-I can run the following set of Git commands to migrate my changes to a new branch and restore master to reflect its state on the remote (typically GitHub.com in my case).
-
-```bash
-git branch new-branch
-git reset origin/master --hard
-git checkout new-branch
-```
-
-Let me walk through this with some pictures for the visual among you.
-
-So here's the state of my repository before I got all itchy trigger finger on it.
+The following diagram shows the state of my repository before I got all itchy trigger finger on it.
 
 ![Original state](https://cloud.githubusercontent.com/assets/19977/8369477/2d2b8812-1b6f-11e5-9e68-190f988172af.png)
 
-As you can see, I have two commits to the `master` branch. HEAD points to the tip of my current branch. You can also see a remote tracking branch named `origin/master`. So at this point, my local `master` matches the `master` on the server as far as I can tell.
+As you can see, I have two commits to the `master` branch. HEAD points to the tip of my current branch. You can also see a remote tracking branch named `origin/master` (_this is a special branch that tracks the `master` branch on the remote server_). So at this point, my local `master` matches the `master` on the server.
 
-This is when I am struck by inspiration and I start some work.
+This is the state of my repository when I am struck by inspiration and I start to code.
 
 ![First Commit](https://cloud.githubusercontent.com/assets/19977/8369476/2d2ab536-1b6f-11e5-8971-079be907489a.png)
 
@@ -40,7 +34,7 @@ I make one commit. Then two.
 
 ![Second Commit - It's fixing time!](https://cloud.githubusercontent.com/assets/19977/8369478/2d2bd268-1b6f-11e5-893b-abeceefb4650.png)
 
-Each time I make a commit, the local `master` branch is updated to the new commit. Uh oh! I meant to create these two commits on a new branch creatively named `new-branch`. I better fix this up.
+Each time I make a commit, the local `master` branch is updated to the new commit. Uh oh! As in the scenario in the opening paragraph, I meant to create these two commits on a new branch creatively named `new-branch`. I better fix this up.
 
 So the first thing I do is create this branch without switching to it.
 
@@ -48,9 +42,9 @@ So the first thing I do is create this branch without switching to it.
 
 ![new branch](https://cloud.githubusercontent.com/assets/19977/8369479/2d2f10d6-1b6f-11e5-8fe9-0a30c4b4ad27.png)
 
-Notice that `HEAD` still points to `master`. Also note that `new-branch` simply points to the same location. This is why branching is so cheap. A branch is just a pointer to a commit.
+Notice that `HEAD` still points to `master`. Also note that `new-branch` points to the same location. This is why branching is so cheap. A branch is just a pointer to a commit.
 
-Creating a branch pointing to the latest commit makes it safe for me to reset the master branch back to the state it is on the server.
+I created a branch that points to the latest commit to make it safe for me to reset the master branch back to the state it is on the server. I want to make sure I have an easy way to still reference the commit that the branch points to before I reset it.
 
 `git reset origin/master --hard`
 
@@ -64,21 +58,23 @@ Now I can simply check out the `new-branch` and continue my work.
 
 This moves `HEAD` to the new branch and now I can continue to work on the branch as if I had never made this mistake. Yay!
 
+Here's the set of commands that I ran all together.
+
+```bash
+git branch new-branch
+git reset origin/master --hard
+git checkout new-branch
+```
+
 ### Fixing up a non-master branch
 
 ![The wrong branch](https://cloud.githubusercontent.com/assets/19977/8369613/48019364-1b71-11e5-9a28-b748a2802ed7.png)
 
-This case is a bit more complicated. Here I have a branch named `wrong-branch` that is my current branch. But I thought I was working in the master branch. I inadverdently make two commits in this branch, leaving us in this fine mess.
+This case is a bit more complicated. Here I have a branch named `wrong-branch` that is my current branch. But I thought I was working in the `master` branch. I make two commits in this branch by `mistake` which causes this fine mess.
 
 ![A fine mess](https://cloud.githubusercontent.com/assets/19977/8369614/4801b83a-1b71-11e5-898a-4c116e83b749.png)
 
 What I want here is to migrate commits `E` and `F` to a new branch off of `master`. Here's the set of commands.
-
-```bash
-git branch new-branch
-git reset origin/wrong-branch --hard
-git rebase --onto master origin/wrong-branch new-branch
-```
 
 Let's walk through these steps one by one. Not to worry, as before, I create a new branch.
 
@@ -98,15 +94,27 @@ But now, I need to move the `new-branch` onto `master`.
 
 ![Final result](https://cloud.githubusercontent.com/assets/19977/8382092/06f71640-1be5-11e5-9f90-2b433bd6ffd8.png)
 
-As you know, the `git rebase` command is the way you move (well, actually you replay) commits onto other branches. The handy `--onto` flag makes it possible to specify a range of commits to move elsewhere. [Pivotal Labs has a helpful post](http://pivotallabs.com/git-rebase-onto/) that describes this option in more detail. So in this case, I moved commits `E` and `F` because they are the ones between `origin/wrong-branch` exclusive and `new-branch` inclusive.
+The `git rebase` command is a great way to move (well, actually you replay commits, but that's a story for another day) commits onto other branches. The handy `--onto` flag makes it possible to specify a range of commits to move elsewhere. [Pivotal Labs has a helpful post](http://pivotallabs.com/git-rebase-onto/) that describes this option in more detail.
 
-### Fix up local only branches
+So in this case, I moved commits `E` and `F` because they are the ones between `origin/wrong-branch` exclusive and `new-branch` inclusive
 
-The assumption I made in the past two examples is that I'm working with branches that I've pushed to a remote. That's a convenient scenario because the version of the branch on the server (the remote) is a handy "Save Point" that I can reset to in the form of the remote tracking branch (the ones named `origin/*`).
+Here's the set of command I ran all together.
 
-This makes it easy to find the range of commits that are only on my machine and move those.
+```bash
+git branch new-branch
+git reset origin/wrong-branch --hard
+git rebase --onto master origin/wrong-branch new-branch
+```
 
-But I could be in the situation where I don't have a remote branch. Or maybe the branch I started muddying up already had a local commit.
+### Migrate commit ranges - great for local only branches
+
+The assumption I made in the past two examples is that I'm working with branches that I've pushed to a remote. When you push a branch to a remote, you can create a local "remote tracking branch" that tracks the state of the branch on the remote server using the `-u` option.
+
+For example, when I pushed the `wrong-branch`, I ran the command `git push -u origin wrong-branch` which not only pushes the branch to the remote (named `origin`), but creates the branch named `origin/wrong-branch` which corresponds to the state of `wrong-branch` on the server.
+
+I can use a remote tracking branch as a convenient "Save Point" that I can reset to if I accidentally make commits on the corresponding local branch. It makes it easy to find the range of commits that are only on my machine and move just those.
+
+But I could be in the situation where I don't have a remote branch. Or maybe the branch I started muddying up already had a local commit that I _don't_ want to move.
 
 That's fine, I can just specify a commit range. For example, if I only wanted to move the last commit on `wrong-branch` into a new branch, I might do this.
 
@@ -118,7 +126,9 @@ git rebase --onto master HEAD~1 new-branch
 
 ### Alias was a fine TV show, but a better Git technique
 
-What I've shown are rote series of steps. Sounds like a job for a Git Alias! Aliases are a powerful way of automating or extending Git with your own Git commands.
+When you see the set of commands I ran, I hope you're thinking "Hey, that looks like a rote series of steps and you should automate that!" This is why I like you. You're very clever and very correct!
+
+Automating a series of git commands sounds like a job for a Git Alias! Aliases are a powerful way of automating or extending Git with your own Git commands.
 
 In a blog post I wrote last year, [GitHub Flow Like a Pro with these 13 Git aliases](http://haacked.com/archive/2014/07/28/github-flow-aliases/), I wrote about some aliases I use to support my workflow.
 
@@ -130,7 +140,7 @@ Well now I have one more to add to this list. I decided to call this alias, `mig
 
 So if I'm on `master` with a repository that's tracking a remote and I want move my local commits to a new branch, I'd just run `git migrate new-branch`.
 
-If I'm not on master, but on a branch named `wrong-branch` I'd just do this:
+If I'm not on `master`, but on a branch named `wrong-branch` I'd just do this:
 
 `git migrate new-branch origin/wrong-branch`
 

--- a/_posts/2015/2015-06-26-git-migrate.markdown
+++ b/_posts/2015/2015-06-26-git-migrate.markdown
@@ -1,0 +1,139 @@
+---
+layout: post
+title: "Git Alias To Migrate Commits To A Branch"
+date: 2015-06-26 -0800
+comments: true
+categories: [github git]
+---
+
+Show of hands if this happens to you. You get excited about an idea and just start writing code and creating commits only to realize you're in the wrong branch. Well, you'll have to tell me about it in the comments because I can't see your hands. This happens to me all the time because I lack impulse control.
+
+As you may know, a key component of the GitHub Flow workflow is to do all new feature work in a branch. Fixing a bug? Create a branch! Adding a new feature? Create a branch! Need to climbe a tree? Well, you get the picture.
+
+So what happens when you run into this situation? Are you stuck? Heavens no! [The thing about Git](http://2ndscale.com/rtomayko/2008/the-thing-about-git) is that its very design supports fixing up mistakes after the fact. It's very forgiving in this regard. For example, a recent blog post on the GitHub blog highlights all the different ways [you can undo mistakes in Git](https://github.com/blog/2019-how-to-undo-almost-anything-with-git).
+
+### Fixing up `master`
+
+This is the simple case. I made commits on master that were intended for a branch off of master.
+
+I can run the following set of Git commands to migrate my changes to a new branch and restore master to reflect its state on the remote (typically GitHub.com in my case).
+
+```bash
+git branch new-branch
+git reset origin/master --hard
+git checkout new-branch
+```
+
+Let me walk through this with some pictures for the visual among you.
+
+So here's the state of my repository before I got all itchy trigger finger on it.
+
+![Original state](https://cloud.githubusercontent.com/assets/19977/8369477/2d2b8812-1b6f-11e5-9e68-190f988172af.png)
+
+As you can see, I have two commits to the `master` branch. HEAD points to the tip of my current branch. You can also see a remote tracking branch named `origin/master`. So at this point, my local `master` matches the `master` on the server as far as I can tell.
+
+This is when I am struck by inspiration and I start some work.
+
+![First Commit](https://cloud.githubusercontent.com/assets/19977/8369476/2d2ab536-1b6f-11e5-8971-079be907489a.png)
+
+I make one commit. Then two.
+
+![Second Commit - It's fixing time!](https://cloud.githubusercontent.com/assets/19977/8369478/2d2bd268-1b6f-11e5-893b-abeceefb4650.png)
+
+Each time I make a commit, the local `master` branch is updated to the new commit. Uh oh! I meant to create these two commits on a new branch creatively named `new-branch`. I better fix this up.
+
+So the first thing I do is create this branch without switching to it.
+
+`git branch new-branch`
+
+![new branch](https://cloud.githubusercontent.com/assets/19977/8369479/2d2f10d6-1b6f-11e5-8fe9-0a30c4b4ad27.png)
+
+Notice that `HEAD` still points to `master`. Also note that `new-branch` simply points to the same location. This is why branching is so cheap. A branch is just a pointer to a commit.
+
+Creating a branch pointing to the latest commit makes it safe for me to reset the master branch back to the state it is on the server.
+
+`git reset origin/master --hard`
+
+![master restored](https://cloud.githubusercontent.com/assets/19977/8369481/2d3feabe-1b6f-11e5-91ff-22fc27d0d13b.png)
+
+Notice that `HEAD` and `master` are back to their original position, but `new-branch` continues to point to the latest commit.
+
+Now I can simply check out the `new-branch` and continue my work.
+
+![checkout the new branch](https://cloud.githubusercontent.com/assets/19977/8369480/2d3d416a-1b6f-11e5-94c8-301aa8fbd4d1.png)
+
+This moves `HEAD` to the new branch and now I can continue to work on the branch as if I had never made this mistake. Yay!
+
+### Fixing up a non-master branch
+
+![The wrong branch](https://cloud.githubusercontent.com/assets/19977/8369613/48019364-1b71-11e5-9a28-b748a2802ed7.png)
+
+This case is a bit more complicated. Here I have a branch named `wrong-branch` that is my current branch. But I thought I was working in the master branch. I inadverdently make two commits in this branch, leaving us in this fine mess.
+
+![A fine mess](https://cloud.githubusercontent.com/assets/19977/8369614/4801b83a-1b71-11e5-898a-4c116e83b749.png)
+
+What I want here is to migrate commits `E` and `F` to a new branch off of `master`. Here's the set of commands.
+
+```bash
+git branch new-branch
+git reset origin/wrong-branch --hard
+git rebase --onto master origin/wrong-branch new-branch
+```
+
+Let's walk through these steps one by one. Not to worry, as before, I create a new branch.
+
+`git branch new-branch`
+
+![A new branch](https://cloud.githubusercontent.com/assets/19977/8369616/48025ac4-1b71-11e5-9e0f-114e9bbb0001.png)
+
+Again, just like before, I reset the current branch to the state of the current branch as it exists on the server.
+
+`git reset origin/wrong-branch --hard`
+
+![Reset the current branch](https://cloud.githubusercontent.com/assets/19977/8369612/47fe6374-1b71-11e5-92dd-26ddf71d5a7a.png)
+
+But now, I need to move the `new-branch` onto `master`.  
+
+`git rebase --onto master origin/wrong-branch new-branch`
+
+![Final result](https://cloud.githubusercontent.com/assets/19977/8369725/e974c09e-1b72-11e5-8b1d-dc1eeb223502.png)
+
+As you know, the `git rebase` command is the way you move (well, actually you replay) commits onto other branches. The `--onto` flag makes it possible to specify a range of commits to move elsewhere. So in this case, I moved commits `E` and `F` because they are the ones between `origin/wrong-branch` exclusive and `new-branch` inclusive.
+
+### Fix up local only branches
+
+The assumption I made in the past two examples is that I'm working with branches that I've pushed to a remote. This makes it easy to find the range of commits that are only on my machine and move those.
+
+But I could be in the situation where I don't have a remote branch. Or maybe the branch I started muddying up already had a local commit.
+
+That's fine, I can just specify a commit range. For example, if I only wanted to move the last two commits on `master` into a new branch, I might do this.
+
+```bash
+git branch new-branch
+git reset HEAD~2 --hard
+git checkout new-branch
+```
+
+### Alias was a fine TV show, but a better Git technique
+
+What I've shown are rote series of steps. Sounds like a job for a Git Alias! Aliases are a powerful way of automating or extending Git with your own Git commands.
+
+In a blog post I wrote last year, [GitHub Flow Like a Pro with these 13 Git aliases](http://haacked.com/archive/2014/07/28/github-flow-aliases/), I wrote about some aliases I use to support my workflow.
+
+Well now I have one more to add to this list. I decided to call this alias, `migrate`.
+
+```
+    migrate = "!f(){ git branch $1 && git reset @{u} --hard && git rebase --onto ${2-master} @{u} $1; }; f"
+```
+
+So if I'm on `master` with a repository that's tracking a remote and I want move my local commits to a new branch, I'd just run `git migrate new-branch`.
+
+If I'm not on master, but on a branch named `wrong-branch` I'd just do this:
+
+`git migrate new-branch origin/wrong-branch`
+
+Here's the output from that command using the second example where I migrate commits `E` and `F` to a new branch.
+
+![git migrate command output](https://cloud.githubusercontent.com/assets/19977/8381990/681cd2c6-1be4-11e5-96db-56e4cee7306c.png)
+
+And there you go. A nice alias that automates a set of steps to fix a common mistake. Let me know if you find it useful!

--- a/_posts/2015/2015-06-26-git-migrate.markdown
+++ b/_posts/2015/2015-06-26-git-migrate.markdown
@@ -96,9 +96,9 @@ But now, I need to move the `new-branch` onto `master`.
 
 `git rebase --onto master origin/wrong-branch new-branch`
 
-![Final result](https://cloud.githubusercontent.com/assets/19977/8369725/e974c09e-1b72-11e5-8b1d-dc1eeb223502.png)
+![Final result](https://cloud.githubusercontent.com/assets/19977/8382092/06f71640-1be5-11e5-9f90-2b433bd6ffd8.png)
 
-As you know, the `git rebase` command is the way you move (well, actually you replay) commits onto other branches. The `--onto` flag makes it possible to specify a range of commits to move elsewhere. So in this case, I moved commits `E` and `F` because they are the ones between `origin/wrong-branch` exclusive and `new-branch` inclusive.
+As you know, the `git rebase` command is the way you move (well, actually you replay) commits onto other branches. The handy `--onto` flag makes it possible to specify a range of commits to move elsewhere. [Pivotal Labs has a helpful post](http://pivotallabs.com/git-rebase-onto/) that describes this option in more detail. So in this case, I moved commits `E` and `F` because they are the ones between `origin/wrong-branch` exclusive and `new-branch` inclusive.
 
 ### Fix up local only branches
 

--- a/_posts/2015/2015-06-29-git-migrate.markdown
+++ b/_posts/2015/2015-06-29-git-migrate.markdown
@@ -148,4 +148,6 @@ Here's the output from that command using the second example where I migrate com
 
 ![git migrate command output](https://cloud.githubusercontent.com/assets/19977/8381990/681cd2c6-1be4-11e5-96db-56e4cee7306c.png)
 
+I can also migrate the commits to a branch created off of something other than `master` - `git migrate new-branch other-branch`
+
 And there you go. A nice alias that automates a set of steps to fix a common mistake. Let me know if you find it useful!

--- a/_posts/2015/2015-06-29-git-migrate.markdown
+++ b/_posts/2015/2015-06-29-git-migrate.markdown
@@ -67,32 +67,32 @@ What I want here is to migrate commits `E` and `F` to a new branch off of `maste
 
 Let's walk through these steps one by one. Not to worry, as before, I create a new branch.
 
-`git branch new-branch`
+`git checkout -b new-branch`
 
-![Always a new branch](https://cloud.githubusercontent.com/assets/19977/8390535/e6a2c114-1c4d-11e5-8fd7-0911a8238334.png)
+![Always a new branch](https://cloud.githubusercontent.com/assets/19977/8412077/4d85a08c-1e3c-11e5-98eb-c421d2cf5159.png)
 
-Again, just like before, I reset the current branch to the state of the current branch as it exists on the server.
+Again, just like before, I force the current branch to the state of the current branch as it exists on the server.
 
-`git reset origin/wrong-branch --hard`
+`git branch --force wrong-branch origin/wrong-branch`
 
-![Reset the current branch](https://cloud.githubusercontent.com/assets/19977/8369612/47fe6374-1b71-11e5-92dd-26ddf71d5a7a.png)
+![force branch](https://cloud.githubusercontent.com/assets/19977/8412113/93984c46-1e3c-11e5-9329-f38adb158dcd.png)
 
 But now, I need to move the `new-branch` onto `master`.  
 
-`git rebase --onto master origin/wrong-branch new-branch`
+`git rebase --onto master wrong-branch`
 
 ![Final result](https://cloud.githubusercontent.com/assets/19977/8382092/06f71640-1be5-11e5-9f90-2b433bd6ffd8.png)
 
 The `git rebase` command is a great way to move (well, actually you replay commits, but that's a story for another day) commits onto other branches. The handy `--onto` flag makes it possible to specify a range of commits to move elsewhere. [Pivotal Labs has a helpful post](http://pivotallabs.com/git-rebase-onto/) that describes this option in more detail.
 
-So in this case, I moved commits `E` and `F` because they are the ones between `origin/wrong-branch` exclusive and `new-branch` inclusive
+So in this case, I moved commits `E` and `F` because they are the ones since `wrong-branch` on the current branch, `new-branch`.
 
 Here's the set of command I ran all together.
 
 ```bash
-git branch new-branch
-git reset origin/wrong-branch --hard
-git rebase --onto master origin/wrong-branch new-branch
+git checkout -b new-branch
+git branch --force wrong-branch origin/wrong-branch
+git rebase --onto master wrong-branch
 ```
 
 ### Migrate commit ranges - great for local only branches

--- a/_posts/2015/2015-06-29-git-migrate.markdown
+++ b/_posts/2015/2015-06-29-git-migrate.markdown
@@ -148,3 +148,5 @@ And finally, if I want to just migrate the last commit to a new branch created o
 `git migrate new-branch master HEAD~1`
 
 And there you go. A nice alias that automates a set of steps to fix a common mistake. Let me know if you find it useful!
+
+Also, I want to give a special thanks to [@mhagger](https://github.com/mhagger) for his help with this post. The [original draft](https://github.com/mhagger) had the grace of a two-year-old neurosurgeon with a mallet. The straightforward Git commands I proposed would rewrite the working tree twice. With his proposed changes, this alias never rewrites the working tree. Like math, there's often often a more elegant solution with Git once you understand the available tools.

--- a/_posts/2015/2015-06-29-git-migrate.markdown
+++ b/_posts/2015/2015-06-29-git-migrate.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Git Alias To Migrate Commits To A Branch"
-date: 2015-06-26 -0800
+date: 2015-06-29 -0800
 comments: true
 categories: [github git]
 ---

--- a/_posts/2015/2015-06-29-git-migrate.markdown
+++ b/_posts/2015/2015-06-29-git-migrate.markdown
@@ -6,7 +6,7 @@ comments: true
 categories: [github git]
 ---
 
-Show of hands if this ever happens to you. After a long day of fighting fires at work, you settle into your favorite chair to unwind and write code. Your fingers fly over the keyboard punctuating your code with semi-colons or paretheses or whatever is appropriate.
+Show of hands if this ever happens to you. After a long day of fighting fires at work, you settle into your favorite chair to unwind and write code. Your fingers fly over the keyboard punctuating your code with semi-colons or parentheses or whatever is appropriate.
 
 But after a few commits, it dawns on you that you're in the wrong branch. Yeah? Me too. This happens to me all the time because I lack impulse control. You can put your hands down now.
 
@@ -36,34 +36,23 @@ I make one commit. Then two.
 
 Each time I make a commit, the local `master` branch is updated to the new commit. Uh oh! As in the scenario in the opening paragraph, I meant to create these two commits on a new branch creatively named `new-branch`. I better fix this up.
 
-So the first thing I do is create this branch without switching to it.
+The first step is to create the new branch. We can create it and check it out all in one step.
 
-`git branch new-branch`
+`git checkout -b new-branch`
 
-![Create a new branch named new-branch](https://cloud.githubusercontent.com/assets/19977/8390500/bbe365ec-1c4c-11e5-83e6-eb60f7155efe.png)
+![checkout a new branch](https://cloud.githubusercontent.com/assets/19977/8411869/0ba24220-1e3b-11e5-9895-42c486709937.png)
 
-Notice that `HEAD` still points to `master`. Also note that `new-branch` points to the same location. This is why branching is so cheap. A branch is just a pointer to a commit.
+At this point, both the `new-branch` and `master` point to the same commit. Now I can force the master branch back to its original position.
 
-I created a branch that points to the latest commit to make it safe for me to reset the master branch back to the state it is on the server. I want to make sure I have an easy way to still reference the commit that the branch points to before I reset it.
+`git branch --force master origin/master`
 
-`git reset origin/master --hard`
-
-![Reset master back to its original position](https://cloud.githubusercontent.com/assets/19977/8390501/bbf39b24-1c4c-11e5-8d7a-b1cf7b4bcb5b.png)
-
-Notice that `HEAD` and `master` are back to their original position, but `new-branch` continues to point to the latest commit.
-
-Now I can simply check out the `new-branch` and continue my work.
-
-![Checkout new-branch and we are done](https://cloud.githubusercontent.com/assets/19977/8390502/bbf69180-1c4c-11e5-920a-7991e341eefa.png)
-
-This moves `HEAD` to the new branch and now I can continue to work on the branch as if I had never made this mistake. Yay!
+![force branch master](https://cloud.githubusercontent.com/assets/19977/8411975/b05c941e-1e3b-11e5-8e84-f36535fb7893.png)
 
 Here's the set of commands that I ran all together.
 
 ```bash
-git branch new-branch
-git reset origin/master --hard
-git checkout new-branch
+git checkout -b new-branch
+git branch --force master origin/master
 ```
 
 ### Fixing up a non-master branch

--- a/_posts/2015/2015-06-29-git-migrate.markdown
+++ b/_posts/2015/2015-06-29-git-migrate.markdown
@@ -80,7 +80,7 @@ Let's walk through these steps one by one. Not to worry, as before, I create a n
 
 `git branch new-branch`
 
-![A new branch](https://cloud.githubusercontent.com/assets/19977/8369616/48025ac4-1b71-11e5-9e0f-114e9bbb0001.png)
+![Always a new branch](https://cloud.githubusercontent.com/assets/19977/8390535/e6a2c114-1c4d-11e5-8fd7-0911a8238334.png)
 
 Again, just like before, I reset the current branch to the state of the current branch as it exists on the server.
 

--- a/_posts/2015/2015-06-29-git-migrate.markdown
+++ b/_posts/2015/2015-06-29-git-migrate.markdown
@@ -108,9 +108,9 @@ But I could be in the situation where I don't have a remote branch. Or maybe the
 That's fine, I can just specify a commit range. For example, if I only wanted to move the last commit on `wrong-branch` into a new branch, I might do this.
 
 ```bash
-git branch new-branch
-git reset HEAD~1 --hard
-git rebase --onto master HEAD~1 new-branch
+git checkout -b new-branch
+git branch --force wrong-branch HEAD~1
+git rebase --onto master wrong-branch
 ```
 
 ### Alias was a fine TV show, but a better Git technique

--- a/_posts/2015/2015-06-29-git-migrate.markdown
+++ b/_posts/2015/2015-06-29-git-migrate.markdown
@@ -22,17 +22,17 @@ This is the simple case. I made commits on master that were intended for a branc
 
 The following diagram shows the state of my repository before I got all itchy trigger finger on it.
 
-![Original state](https://cloud.githubusercontent.com/assets/19977/8369477/2d2b8812-1b6f-11e5-9e68-190f988172af.png)
+![Initial state](https://cloud.githubusercontent.com/assets/19977/8390497/bbde5f8e-1c4c-11e5-9760-9e94236423d6.png)
 
 As you can see, I have two commits to the `master` branch. HEAD points to the tip of my current branch. You can also see a remote tracking branch named `origin/master` (_this is a special branch that tracks the `master` branch on the remote server_). So at this point, my local `master` matches the `master` on the server.
 
 This is the state of my repository when I am struck by inspiration and I start to code.
 
-![First Commit](https://cloud.githubusercontent.com/assets/19977/8369476/2d2ab536-1b6f-11e5-8971-079be907489a.png)
+![First](https://cloud.githubusercontent.com/assets/19977/8390499/bbe3174a-1c4c-11e5-87ee-75aacf1a197a.png)
 
 I make one commit. Then two.
 
-![Second Commit - It's fixing time!](https://cloud.githubusercontent.com/assets/19977/8369478/2d2bd268-1b6f-11e5-893b-abeceefb4650.png)
+![Second Commit - fixing time](https://cloud.githubusercontent.com/assets/19977/8390498/bbe2c524-1c4c-11e5-98c3-7526ae2277f9.png)
 
 Each time I make a commit, the local `master` branch is updated to the new commit. Uh oh! As in the scenario in the opening paragraph, I meant to create these two commits on a new branch creatively named `new-branch`. I better fix this up.
 
@@ -40,7 +40,7 @@ So the first thing I do is create this branch without switching to it.
 
 `git branch new-branch`
 
-![new branch](https://cloud.githubusercontent.com/assets/19977/8369479/2d2f10d6-1b6f-11e5-8fe9-0a30c4b4ad27.png)
+![Create a new branch named new-branch](https://cloud.githubusercontent.com/assets/19977/8390500/bbe365ec-1c4c-11e5-83e6-eb60f7155efe.png)
 
 Notice that `HEAD` still points to `master`. Also note that `new-branch` points to the same location. This is why branching is so cheap. A branch is just a pointer to a commit.
 
@@ -48,13 +48,13 @@ I created a branch that points to the latest commit to make it safe for me to re
 
 `git reset origin/master --hard`
 
-![master restored](https://cloud.githubusercontent.com/assets/19977/8369481/2d3feabe-1b6f-11e5-91ff-22fc27d0d13b.png)
+![Reset master back to its original position](https://cloud.githubusercontent.com/assets/19977/8390501/bbf39b24-1c4c-11e5-8d7a-b1cf7b4bcb5b.png)
 
 Notice that `HEAD` and `master` are back to their original position, but `new-branch` continues to point to the latest commit.
 
 Now I can simply check out the `new-branch` and continue my work.
 
-![checkout the new branch](https://cloud.githubusercontent.com/assets/19977/8369480/2d3d416a-1b6f-11e5-94c8-301aa8fbd4d1.png)
+![Checkout new-branch and we are done](https://cloud.githubusercontent.com/assets/19977/8390502/bbf69180-1c4c-11e5-920a-7991e341eefa.png)
 
 This moves `HEAD` to the new branch and now I can continue to work on the branch as if I had never made this mistake. Yay!
 
@@ -132,7 +132,7 @@ Automating a series of git commands sounds like a job for a Git Alias! Aliases a
 
 In a blog post I wrote last year, [GitHub Flow Like a Pro with these 13 Git aliases](http://haacked.com/archive/2014/07/28/github-flow-aliases/), I wrote about some aliases I use to support my workflow.
 
-Well now I have one more to add to this list. I decided to call this alias, `migrate`.
+Well now I have one more to add to this list. I decided to call this alias, `migrate`. Here's the definition for the alias. Notice that it uses `git rebase --onto` which we used for the second scenario I described. It turns out that this happens to work for the first scenario too.
 
 ```
     migrate = "!f(){ git branch $1 && git reset @{u} --hard && git rebase --onto ${2-master} @{u} $1; }; f"

--- a/_posts/2015/2015-06-29-git-migrate.markdown
+++ b/_posts/2015/2015-06-29-git-migrate.markdown
@@ -124,19 +124,27 @@ In a blog post I wrote last year, [GitHub Flow Like a Pro with these 13 Git alia
 Well now I have one more to add to this list. I decided to call this alias, `migrate`. Here's the definition for the alias. Notice that it uses `git rebase --onto` which we used for the second scenario I described. It turns out that this happens to work for the first scenario too.
 
 ```
-    migrate = "!f(){ git branch $1 && git reset @{u} --hard && git rebase --onto ${2-master} @{u} $1; }; f"
+    migrate = "!f(){ CURRENT=$(git symbolic-ref --short HEAD); git checkout -b $1 && git branch --force $CURRENT ${3-'$CURRENT@{u}'} && git rebase --onto ${2-master} $CURRENT; }; f"
 ```
 
-So if I'm on `master` with a repository that's tracking a remote and I want move my local commits to a new branch, I'd just run `git migrate new-branch`.
+There's a lot going on here and I could probably write a whole blog post unpacking it, but for now I'll try and focus on the usage pattern.
 
-If I'm not on `master`, but on a branch named `wrong-branch` I'd just do this:
+This alias has one required parameter, the new branch name, and two optional parameters.
 
-`git migrate new-branch origin/wrong-branch`
+```
+branch-name   required  The name of the new branch to migrate to
+target-branch optional  Defaults to "master". The branch to create the new branch off of
+commit-range  optional  The set of commits to migrate. Defaults to the current remote tracking branch.
+```
 
-Here's the output from that command using the second example where I migrate commits `E` and `F` to a new branch.
+This command always migrates the current branch.
 
-![git migrate command output](https://cloud.githubusercontent.com/assets/19977/8381990/681cd2c6-1be4-11e5-96db-56e4cee7306c.png)
+If I'm on a branch and want to migrate the local only commits over to `master`, I can just run `git migrate new-branch-name`. This works whether I'm on `master` or some other wrong branch.
 
 I can also migrate the commits to a branch created off of something other than `master` - `git migrate new-branch other-branch`
+
+And finally, if I want to just migrate the last commit to a new branch created off of master, I can do this.
+
+`git migrate new-branch master HEAD~1`
 
 And there you go. A nice alias that automates a set of steps to fix a common mistake. Let me know if you find it useful!


### PR DESCRIPTION
- [ ] Still need to resolve the problem with migrating specific ranges of commits

The final scenario I want to make work is when you want to migrate a commit range instead of every _local_ commit.

Here's the alias I have so far:

```bash
    migrate = "!f(){ git branch $1 && git reset ${3-'@{u}'} --hard && git rebase --onto ${2-master} ${3-'@{u}'} $1; }; f"
```

Now take a look at this tree.

![](https://cloud.githubusercontent.com/assets/19977/8369614/4801b83a-1b71-11e5-898a-4c116e83b749.png)

If I run `git migrate new-branch` everything works great. That would expand to the following commands:

```bash
git branch new-branch
git reset origin/wrong-branch --hard
git rebase --onto master origin/wrong-branch new-branch
```

And that seems to result correctly in `wrong-branch` being reset to `origin/wrong-branch` AND commits `E` and `F` (but not `D`) migrated to a branch `new-branch` off of master.

However, if I run `git migrate new-branch master HEAD~1` I would expect that `wrong-branch` is reset to `E` (which it is) and that the commit `F` is migrated to the `new-branch` off of `master`. But what happens is that `E` and `F` are rebased, which is a bit confusing to me.

So after talking to @mhagger it looks like I might need to add some complexity to the alias so that if you happen to pass in a 3rd parameter, I reset to that parameter, but I rebase onto that parameter~1.

Maybe I could set the right "savepoint" to a variable

```bash
    migrate = "!f(){ savepoint = if test -n "$3"; then $3^ else @{u} fi; ..."
```

Then I'd `reset` to `savepoint` but `rebase --onto` using `savepoint^`.
