### PR TITLE
easier to read

### DIFF
--- a/_posts/2015/2015-06-29-git-migrate.markdown
+++ b/_posts/2015/2015-06-29-git-migrate.markdown
@@ -131,17 +131,19 @@ There's a lot going on here and I could probably write a whole blog post unpacki
 
 This alias has one required parameter, the new branch name, and two optional parameters.
 
+```
 ! parameter         ! type     ! Description                                                             !
 |-------------------|----------|-------------------------------------------------------------------------|
 | __branch-name__   | required | Name of the new branch                                                  |
 | __target-branch__ | optional | Defaults to "master". The branch that the new branch is created off of. |
 | __commit-range__  | optional | The commits to migrate. Defaults to the current remote tracking branch. |
+```
 
 This command always migrates the current branch.
 
 If I'm on a branch and want to migrate the local only commits over to `master`, I can just run `git migrate new-branch-name`. This works whether I'm on `master` or some other wrong branch.
 
-I can also migrate the commits to a branch created off of something other than `master` - `git migrate new-branch other-branch`
+I can also migrate the commits to a branch created off of something other than `master` using this command: `git migrate new-branch other-branch`
 
 And finally, if I want to just migrate the last commit to a new branch created off of master, I can do this.
 


### PR DESCRIPTION
- keep format of the parameters table for the alias
- a more distinct separation of the master branch name and the command makes it clearer to read