### PR TITLE
Setup a redirect from an old URL

### DIFF
--- a/_posts/archived/2004-08-20-resharper-property-expansion-live-template.aspx.markdown
+++ b/_posts/archived/2004-08-20-resharper-property-expansion-live-template.aspx.markdown
@@ -4,6 +4,7 @@ title: "ReSharper Property Expansion Live Template"
 date: 2004-08-20 -0800
 comments: true
 disqus_identifier: 954
+redirect_from: "/archive/2004/08/20/954.aspx.html"
 categories: []
 ---
 One thing I liked about CodeRush is that it came with several property


### PR DESCRIPTION
The post at /2005/10/17/WritingCustomExceptionsUsingResharperLiveTemplates.aspx links to /archive/2004/08/20/954.aspx, which should redirect to /archive/2005/10/17/WritingCustomExceptionsUsingResharperLiveTemplates.aspx.