### PR TITLE
Validate an email address: Escape "|"

### DIFF
--- a/_posts/archived/2007-08-21-i-knew-how-to-validate-an-email-address-until-i.aspx.markdown
+++ b/_posts/archived/2007-08-21-i-knew-how-to-validate-an-email-address-until-i.aspx.markdown
@@ -56,7 +56,7 @@ A *dot-atom* is a dot delimited series of atoms. An *atom* is defined in
 a series of alphanumeric characters and may include the following
 characters (*all the ones you need to swear in a comic strip*)...
 
-> ! \$ & \* - = \^ \` | \~ \# % ' + / ? \_ { }
+> ! \$ & \* - = \^ \` \| \~ \# % ' + / ? \_ { }
 
 Not only that, but it’s also valid (though not recommended and very
 uncommon) to have quoted local parts which allow pretty much any


### PR DESCRIPTION
"|" is often used to describe tables, and the list of valid characters is not a table (as far as I can tell.)

This would correct that minor typo.