### PR TITLE
Correct quote rendering in example email addresses

### DIFF
--- a/_posts/archived/2007-08-21-i-knew-how-to-validate-an-email-address-until-i.aspx.markdown
+++ b/_posts/archived/2007-08-21-i-knew-how-to-validate-an-email-address-until-i.aspx.markdown
@@ -45,10 +45,10 @@ character. Quoting can be done via the backslash character (what is commonly kno
 
 **These are all valid email addresses!**
 
--   "Abc\\@def"@example.com
--   "Fred Bloggs"@example.com
--   "Joe\\\\Blow"@example.com
--   "Abc@def"@example.com
+-   \"Abc\\@def\"@example.com
+-   \"Fred Bloggs\"@example.com
+-   \"Joe\\\\Blow\"@example.com
+-   \"Abc@def\"@example.com
 -   customer/department=shipping@example.com
 -   \$A12345@example.com
 -   !def!xyz%abc@example.com


### PR DESCRIPTION
Markdown processing is rendering these " characters as typographer's quotes (aka curly quotes, smart quotes, etc.), which is incorrect given the technical and character set-related nature of the discussion.