### PR TITLE
Fix from jldec

### DIFF
--- a/_posts/archived/2005-05-30-thereisnoperfectdesign.aspx.markdown
+++ b/_posts/archived/2005-05-30-thereisnoperfectdesign.aspx.markdown
@@ -8,7 +8,6 @@ categories:
 - code
 redirect_from:
   - /archive/2005/05/29/thereisnoperfectdesign.aspx
-  - /archive/2005/05/30/thereisnoperfectdesign.aspx
   - /archive/2005/05/31/ThereIsNoPerfectDesign.aspx
 ---
 

--- a/_posts/archived/2006-08-09-asp.netsupervisingcontrollermodelviewpresenterfromschematictounitteststocode.aspx.markdown
+++ b/_posts/archived/2006-08-09-asp.netsupervisingcontrollermodelviewpresenterfromschematictounitteststocode.aspx.markdown
@@ -5,7 +5,6 @@ title: ASP.NET Supervising Controller (Model View Presenter) From Schematic To U
 date: 2006-08-09 -0800
 comments: true
 redirect_from:
-- "/archive/2006/08/09/ASP.NETSupervisingControllerModelViewPresenterFromSchematicToUnitTestsToCode.aspx"
 - "/archive/2006/08/08/asp.netsupervisingcontrollermodelviewpresenterfromschematictounitteststocode.aspx/"
 disqus_identifier: 14779
 categories:


### PR DESCRIPTION
These redirects_from lines appear to cause jekyll some unhappiness
Maybe something changed with case-(in)-sensitive directory names?
cc: @parkr 