### PR TITLE
Add comment count to archives etc.

### DIFF
--- a/_includes/post/comments_link.html
+++ b/_includes/post/comments_link.html
@@ -1,5 +1,10 @@
-{% if post.comments or page.comments %}
-{% capture default_slug %}{{ post.slug | default: (page.title | slugify) }}{% endcapture %}
-{% capture slug %}{{ (post.slug | fallback: default_slug) | downcase }}{% endcapture %}
+{% if post.comments %}
+{% capture post_default_slug %}{{ post.slug | default: (post.title | slugify) }}{% endcapture %}
+{% capture slug %}{{ (post.slug | fallback: post_default_slug) | downcase }}{% endcapture %}
 <span class="comments"><a href="{{ post.url }}#comments">{{  site.data.comments[slug] | size }} comments</a></span>
+{% endif %}
+{% if page.comments %}
+{% capture page_default_slug %}{{ page.slug | default: (page.title | slugify) }}{% endcapture %}
+{% capture slug %}{{ (page.slug | fallback: page_default_slug) | downcase }}{% endcapture %}
+<span class="comments"><a href="{{ page.url }}#comments">{{  site.data.comments[slug] | size }} comments</a></span>
 {% endif %}

--- a/_includes/post/comments_link.html
+++ b/_includes/post/comments_link.html
@@ -1,10 +1,10 @@
 {% if post.comments %}
 {% capture post_default_slug %}{{ post.slug | default: (post.title | slugify) }}{% endcapture %}
 {% capture slug %}{{ (post.slug | fallback: post_default_slug) | downcase }}{% endcapture %}
-<span class="comments"><a href="{{ post.url }}#comments">{{  site.data.comments[slug] | size }} comments</a></span>
+<span class="comments"><a href="{{ post.url }}#comments">{{ site.data.comments[slug] | size }} comments</a></span>
 {% endif %}
 {% if page.comments %}
 {% capture page_default_slug %}{{ page.slug | default: (page.title | slugify) }}{% endcapture %}
 {% capture slug %}{{ (page.slug | fallback: page_default_slug) | downcase }}{% endcapture %}
-<span class="comments"><a href="{{ page.url }}#comments">{{  site.data.comments[slug] | size }} comments</a></span>
+<span class="comments"><a href="{{ page.url }}#comments">{{ site.data.comments[slug] | size }} comments</a></span>
 {% endif %}

--- a/_includes/post/comments_link.html
+++ b/_includes/post/comments_link.html
@@ -1,3 +1,5 @@
 {% if post.comments or page.comments %}
-<span class="comments"><a href="{{ post.url }}#comments">comments</a></span>
+{% capture default_slug %}{{ post.slug | default: (page.title | slugify) }}{% endcapture %}
+{% capture slug %}{{ (post.slug | fallback: default_slug) | downcase }}{% endcapture %}
+<span class="comments"><a href="{{ post.url }}#comments">{{  site.data.comments[slug] | size }} comments</a></span>
 {% endif %}


### PR DESCRIPTION
Now looks like this:

![image](https://user-images.githubusercontent.com/118951/41831425-c6514ad6-77fb-11e8-943f-512da2aa20ad.png)

Not sure why this file currently looks at both post and page variables though. The comment count code is only using post.