### PR TITLE
Comment by Stephen Cleary on comments-for-jekyll-blogs

### DIFF
--- a/_data/comments/comments-for-jekyll-blogs/64713113.yml
+++ b/_data/comments/comments-for-jekyll-blogs/64713113.yml
@@ -1,0 +1,10 @@
+id: 64713113
+date: 2018-06-25T12:53:40.1388377Z
+name: Stephen Cleary
+avatar: https://secure.gravatar.com/avatar/28dde5772b48c92e08b8050411aa5ba8?s=80&d=identicon&r=pg
+message: >-
+  How wild. I am in the process of migrating away from Disqus on my blog (stephencleary.com) to a very similar solution, for very similar reasons!
+
+
+
+  Tip: You can use Staticman instead of running your own Function. I've been using Staticman and am very pleased with it. It has reCAPTCHA integration built-in.


### PR DESCRIPTION
avatar: <img src="https://secure.gravatar.com/avatar/28dde5772b48c92e08b8050411aa5ba8?s=80&d=identicon&r=pg" width="64" height="64" />

How wild. I am in the process of migrating away from Disqus on my blog (stephencleary.com) to a very similar solution, for very similar reasons!

Tip: You can use Staticman instead of running your own Function. I've been using Staticman and am very pleased with it. It has reCAPTCHA integration built-in.