### PR TITLE
Implement plaintext editable div for Firefox

### DIFF
--- a/_includes/comment-new.html
+++ b/_includes/comment-new.html
@@ -6,7 +6,7 @@
     <img src="/images/comments/unknown-avatar.png" data-fallbacksrc="/images/comments/unknown-avatar.png" data-role="user-avatar" alt="avatar" class="avatar" id="avatarPreview" />
     <div id="commenttext">
       <div id="commentstatus" class="status"></div>
-      <div contenteditable="PLAINTEXT-ONLY" tabindex="0" role="textbox" aria-multiline="true" data-role="editable" class="textarea" aria-label="Join the discussion..." id="comment-div"></div>
+      <div contenteditable="true" tabindex="0" role="textbox" aria-multiline="true" data-role="editable" class="textarea plaintext" aria-label="Join the discussion..." id="comment-div" data-target="message"></div>
       <input type="hidden" name="message" id="message" data-required="true" value="" />
     </div>
   </div>

--- a/_scss/comments.scss
+++ b/_scss/comments.scss
@@ -95,7 +95,6 @@ div#comments {
         color: #2a2e2e;
         cursor: text;
         display: block;
-        padding: 6px 10px 8px;
         min-height: 100px;
       }
 
@@ -109,7 +108,7 @@ div#comments {
         display: none;
       }
 
-      [contenteditable=PLAINTEXT-ONLY]:empty:not(:focus):before {
+      [contenteditable]:empty:not(:focus):before {
         color: #687a86;
         line-height: 30px;
         font-size: 18px;

--- a/js/comment-box.js
+++ b/js/comment-box.js
@@ -1,8 +1,37 @@
 Haack.ready(function() {
-
   let form = Haack.get('commentform')
 
   if (form) {
+
+    // Set up any content editors
+    document.querySelectorAll('div[contenteditable][class="plaintext"]').forEach(function(editor) {
+      // Set up the content editable div
+      try {
+          editor.contentEditable="PLAINTEXT-ONLY";
+      } catch(e) {
+          // Firefox hack to prevent rich text from being pasted.
+          editor.contentEditable="true"
+          editor.addEventListener("paste", function(e) {
+            e.preventDefault();
+            if (e.clipboardData && e.clipboardData.getData) {
+              var text = e.clipboardData.getData("text/plain").replace(/(?:\r\n|\r|\n)/g, '<br />')
+              document.execCommand("insertHTML", false, text)
+            } else if (window.clipboardData && window.clipboardData.getData) {
+              var text = window.clipboardData.getData("Text")
+              insertTextAtCursor(text)
+            }
+          })
+      }
+
+      var targetHiddenInput = Haack.get(editor.dataset.target)
+      if (targetHiddenInput) {
+        editor.oninput = (e) => {
+          targetHiddenInput.value = e.target.innerText
+        }
+      }
+    })
+
+    // Set up other stuff
     var emailRegex = /[^@\s]+@[^@\s]+\.[^@\s]+$/
     var avatarPreview = Haack.get('avatarPreview')
     avatarPreview.onerror = (e) => { tryLoad(e.target, 1) }
@@ -39,10 +68,6 @@ Haack.ready(function() {
       }
 
       return possibleAvatars
-    }
-
-    Haack.get('comment-div').oninput = (e) => {
-      Haack.get('message').value = e.target.innerText
     }
 
     Haack.get('identity').onchange = () => {


### PR DESCRIPTION
Wrote a simple implementation to enable plaintext contenteditable DIVs on FF. For more details, check out this repo: https://github.com/Haacked/simple-editable-div

Fixes #350