### PR TITLE
Comment by Eric Lippert on abolish-performance-reviews

### DIFF
--- a/_data/comments/abolish-performance-reviews/e4a81b5d.yml
+++ b/_data/comments/abolish-performance-reviews/e4a81b5d.yml
@@ -1,0 +1,22 @@
+id: e4a81b5d
+date: 2018-07-11T17:23:04.0250929Z
+name: Eric Lippert
+avatar: https://avatars.io/twitter/@ericlippert/medium
+message: >-
+  Great resource; thanks for putting this together!
+
+
+
+  My favourite performance review story, about worker W, W's manager M, and M's director D.
+
+
+
+  W is not doing well on M's team, and M is concerned. W has a great set of skills that are not being used in their current role.  But wait! M has an idea. Team X in the same division has open headcount and needs someone with W's skills.  We'll move W to team X, open up a head on M's team, and hire someone who has the skills needed to make M's team a success. So M puts this plan into effect and W moves over to team X, and coincidentally worker N is available to transfer to M's team, who has the skills needed. Management success!
+
+
+
+  D comes to M's office and says "WHAT THE HELL ARE YOU DOING? I was going to tell you to shaft W at review time.  Now we have to find someone else to shaft, because the review system requires that every team have at least one "goat" that gets a bad performance review. Don't you know that you always need a goat on your team? Go figure out which of your high performers won't quit when we give them a below-average review and no bonus, OH I KNOW, HOW ABOUT THE NEW GUY?"
+
+
+
+  Take a guess as to what company this was at, Phil. I think you can get it in one. :-)


### PR DESCRIPTION
avatar: <img src="https://avatars.io/twitter/@ericlippert/medium" width="64" height="64" />

Great resource; thanks for putting this together!

My favourite performance review story, about worker W, W's manager M, and M's director D.

W is not doing well on M's team, and M is concerned. W has a great set of skills that are not being used in their current role.  But wait! M has an idea. Team X in the same division has open headcount and needs someone with W's skills.  We'll move W to team X, open up a head on M's team, and hire someone who has the skills needed to make M's team a success. So M puts this plan into effect and W moves over to team X, and coincidentally worker N is available to transfer to M's team, who has the skills needed. Management success!

D comes to M's office and says "WHAT THE HELL ARE YOU DOING? I was going to tell you to shaft W at review time.  Now we have to find someone else to shaft, because the review system requires that every team have at least one "goat" that gets a bad performance review. Don't you know that you always need a goat on your team? Go figure out which of your high performers won't quit when we give them a below-average review and no bonus, OH I KNOW, HOW ABOUT THE NEW GUY?"

Take a guess as to what company this was at, Phil. I think you can get it in one. :-)