### PR TITLE
Comment by Eric Easterberg on abolish-performance-reviews

### DIFF
--- a/_data/comments/abolish-performance-reviews/d09b2aec.yml
+++ b/_data/comments/abolish-performance-reviews/d09b2aec.yml
@@ -1,0 +1,14 @@
+id: d09b2aec
+date: 2018-07-11T21:28:42.0045139Z
+name: Eric Easterberg
+avatar: https://avatars.io/twitter/@eeasterberg/medium
+message: >-
+  In response to Eric Lippert's comment, the answer to the last paragraph is... every company.
+
+
+
+  Good post, agree with every single thing in it, but I will expand on one point, giving a counterexample - "Managers have incentives to inflate appraisals."
+
+
+
+  I once worked in a consulting firm where all reviews were discussed and public to every level of management above. My project was perceived as not doing well (actually our part was fine, long story), and our manager managed to do one thing right - she got herself off the project (wife of a partner, another long story). She later had to do the team's annual performance reviews, and she proceeded to ream every single member. We all received just scathing reviews. You see, she had to deflect blame for the perceived project failure, so she was great, she was just supposedly dragged down by a remarkably incompetent team. (And why wasn't she blamed for seeing this and changing the team? Ha, ha.)


### PR DESCRIPTION
avatar: <img src="https://avatars.io/twitter/@eeasterberg/medium" width="64" height="64" />

In response to Eric Lippert's comment, the answer to the last paragraph is... every company.

Good post, agree with every single thing in it, but I will expand on one point, giving a counterexample - "Managers have incentives to inflate appraisals."

I once worked in a consulting firm where all reviews were discussed and public to every level of management above. My project was perceived as not doing well (actually our part was fine, long story), and our manager managed to do one thing right - she got herself off the project (wife of a partner, another long story). She later had to do the team's annual performance reviews, and she proceeded to ream every single member. We all received just scathing reviews. You see, she had to deflect blame for the perceived project failure, so she was great, she was just supposedly dragged down by a remarkably incompetent team. (And why wasn't she blamed for seeing this and changing the team? Ha, ha.)