### PR TITLE
Comment by Travis Laborde on abolish-performance-reviews

### DIFF
--- a/_data/comments/abolish-performance-reviews/cbabe67e.yml
+++ b/_data/comments/abolish-performance-reviews/cbabe67e.yml
@@ -1,0 +1,14 @@
+id: cbabe67e
+date: 2018-07-12T12:41:06.0548901Z
+name: Travis Laborde
+avatar: https://avatars.io/twitter/@travislaborde/medium
+message: >-
+  Phil, I agree with you but I think you've failed to mention the real point behind the performance reviews these days:  HR and Legal.
+
+
+
+  So many companies use these as their "backup" in the case that a dismissed employee files a grievance of some sort.  It is seen as "documentation" that the person was warned, and had ample time to improve before being let go.
+
+
+
+  I think a company wants to frame the performance review in a positive light, but that's just double-speak when the real goal is to use it as a hammer or as insurance.


### PR DESCRIPTION
avatar: <img src="https://avatars.io/twitter/@travislaborde/medium" width="64" height="64" />

Phil, I agree with you but I think you've failed to mention the real point behind the performance reviews these days:  HR and Legal.

So many companies use these as their "backup" in the case that a dismissed employee files a grievance of some sort.  It is seen as "documentation" that the person was warned, and had ample time to improve before being let go.

I think a company wants to frame the performance review in a positive light, but that's just double-speak when the real goal is to use it as a hammer or as insurance.