### PR TITLE
Comment by Shane Bray on abolish-performance-reviews

### DIFF
--- a/_data/comments/abolish-performance-reviews/d30f54d9.yml
+++ b/_data/comments/abolish-performance-reviews/d30f54d9.yml
@@ -1,0 +1,19 @@
+id: d30f54d9
+date: 2018-07-14T01:02:46.6510050Z
+name: Shane Bray
+avatar: https://secure.gravatar.com/avatar/053e3372ce8d529a7e3c80b69f834528?s=80&d=identicon&r=pg
+message: >+
+  “Negative feedback produces negative results” is garbage. I’ve received a lot of negative feedback / “constructive criticism”; although, at times, not really very constructive.  I appreciate it. I welcome it. In fact, I openly and outright ASK FOR IT. 
+
+
+
+  Negative feedback is something that can actually make you better. Sure, you have to come to terms with the fact that you’re not perfect... so what?  IMO, if you can’t take negative feedback, you’re happy being mediocre at best.  How am I supposed to improve without direct feedback. I don’t need soft handed “coaching”. Just tell me what the hell I did wrong so I can fix it, or explain to you why I did it. 
+
+
+
+  I look forward to performance reviews. Perhaps because I’ve NEVER had a bad one. And that, perhaps, is because I welcome criticism and negative feedback.  I’d suggest if you don’t like hearing negative feedback, you’re likely not really interested in doing your best. Frankly, it’s very selfish. You work to reach a common objective, to produce results as a team, and (hopefully) to achieve something worthwhile to add to your legacy. 
+
+
+
+  If you let a little criticism get the best of you, you lack self-confidence and likely the self-awareness required to improve.
+


### PR DESCRIPTION
avatar: <img src="https://secure.gravatar.com/avatar/053e3372ce8d529a7e3c80b69f834528?s=80&d=identicon&r=pg" width="64" height="64" />

“Negative feedback produces negative results” is garbage. I’ve received a lot of negative feedback / “constructive criticism”; although, at times, not really very constructive.  I appreciate it. I welcome it. In fact, I openly and outright ASK FOR IT. 

Negative feedback is something that can actually make you better. Sure, you have to come to terms with the fact that you’re not perfect... so what?  IMO, if you can’t take negative feedback, you’re happy being mediocre at best.  How am I supposed to improve without direct feedback. I don’t need soft handed “coaching”. Just tell me what the hell I did wrong so I can fix it, or explain to you why I did it. 

I look forward to performance reviews. Perhaps because I’ve NEVER had a bad one. And that, perhaps, is because I welcome criticism and negative feedback.  I’d suggest if you don’t like hearing negative feedback, you’re likely not really interested in doing your best. Frankly, it’s very selfish. You work to reach a common objective, to produce results as a team, and (hopefully) to achieve something worthwhile to add to your legacy. 

If you let a little criticism get the best of you, you lack self-confidence and likely the self-awareness required to improve.
