### PR TITLE
Comment by haacked on abolish-performance-reviews

### DIFF
--- a/_data/comments/abolish-performance-reviews/422f8d7e.yml
+++ b/_data/comments/abolish-performance-reviews/422f8d7e.yml
@@ -1,0 +1,62 @@
+id: 422f8d7e
+date: 2018-07-16T19:49:59.0719260Z
+name: haacked
+avatar: https://avatars.io/twitter/@haacked/medium
+message: >-
+  > “Pay according to the market instead.” What ever happened to paying what your worth?
+
+
+
+  I definitely agree with employers paying what employees are worth. But let me ask you, how do you determine worth?
+
+
+
+  The market is one good means to do that. In most cases, when I say "Pay according to the market" I'm equating that with "Pay what people are worth."
+
+
+
+  Note that I'm not saying every company has to pay top of market. But I would suggest indexing to the market. For example, if your company says it'll pay 95% of market, then that company should evaluate the market on a periodic basis and give raises every time the market value goes up.
+
+
+
+  DHH [notes they do this at Basecamp](https://m.signalvnoise.com/how-we-pay-people-at-basecamp-f1d04f4f194b)
+
+
+
+  > Raises happen automatically, once per year, when we review market rates. Our target is to pay everyone at the company in the 95th percentile, or top 5%, of the market, regardless of their role. So whether you work in customer support or ops or programming or design, you’ll be paid in the top 5% for that position.
+
+
+
+  Now there's two possible cases where the worth you bring to a company does not align to the market.
+
+
+
+  1. You're worth less than market.
+
+  2. You're worth more than market.
+
+
+
+  In the first case, an employer would be wise to still base your pay on the market otherwise you would leave. Or they should investigate why your worth is not commensurate with the market value. Are you not living up to the position? Or is a problem on the management side that they're not realizing the value?
+
+
+
+  In the second case, it's always possible that the value and worth you bring to a company is worth more than the market dictates. Perhaps you bring such bespoke and unique skills to the company that you can't be compared to existing markets. In that case, you might say that your pay does match the market, it's just a market of one.
+
+
+
+  What the company has to look at is what the damage to the business would be if you left, and pay enough to keep the risk of that acceptably low and make sure you feel valued. They have to balance that with having enough money left over to continue to operate and grow the business in a sustainable manner.
+
+
+
+  I think this second scenario is actually very rare. In most cases, companies create incentive programs that do not keep up with the market, much less what people are worth.
+
+
+
+  I've written about this in the past:
+
+
+
+  * [The case against pay for performance](https://haacked.com/archive/2014/08/14/pay-for-performance/)
+
+  * [Incentive pay does not work](https://haacked.com/archive/2018/01/15/incentive-pay-does-not-work/)


### PR DESCRIPTION
avatar: <img src="https://avatars.io/twitter/@haacked/medium" width="64" height="64" />

> “Pay according to the market instead.” What ever happened to paying what your worth?

I definitely agree with employers paying what employees are worth. But let me ask you, how do you determine worth?

The market is one good means to do that. In most cases, when I say "Pay according to the market" I'm equating that with "Pay what people are worth."

Note that I'm not saying every company has to pay top of market. But I would suggest indexing to the market. For example, if your company says it'll pay 95% of market, then that company should evaluate the market on a periodic basis and give raises every time the market value goes up.

DHH [notes they do this at Basecamp](https://m.signalvnoise.com/how-we-pay-people-at-basecamp-f1d04f4f194b)

> Raises happen automatically, once per year, when we review market rates. Our target is to pay everyone at the company in the 95th percentile, or top 5%, of the market, regardless of their role. So whether you work in customer support or ops or programming or design, you’ll be paid in the top 5% for that position.

Now there's two possible cases where the worth you bring to a company does not align to the market.

1. You're worth less than market.
2. You're worth more than market.

In the first case, an employer would be wise to still base your pay on the market otherwise you would leave. Or they should investigate why your worth is not commensurate with the market value. Are you not living up to the position? Or is a problem on the management side that they're not realizing the value?

In the second case, it's always possible that the value and worth you bring to a company is worth more than the market dictates. Perhaps you bring such bespoke and unique skills to the company that you can't be compared to existing markets. In that case, you might say that your pay does match the market, it's just a market of one.

What the company has to look at is what the damage to the business would be if you left, and pay enough to keep the risk of that acceptably low and make sure you feel valued. They have to balance that with having enough money left over to continue to operate and grow the business in a sustainable manner.

I think this second scenario is actually very rare. In most cases, companies create incentive programs that do not keep up with the market, much less what people are worth.

I've written about this in the past:

* [The case against pay for performance](https://haacked.com/archive/2014/08/14/pay-for-performance/)
* [Incentive pay does not work](https://haacked.com/archive/2018/01/15/incentive-pay-does-not-work/)