### PR TITLE
Comment by Alessandro Lettieri on fixing-binding-to-decimals-aspx

### DIFF
--- a/_data/comments/fixing-binding-to-decimals-aspx/b9fe2d82.yml
+++ b/_data/comments/fixing-binding-to-decimals-aspx/b9fe2d82.yml
@@ -1,0 +1,9 @@
+id: b9fe2d82
+date: 2018-08-09T09:38:17.8341530Z
+name: Alessandro Lettieri
+avatar: https://secure.gravatar.com/avatar/770aa719b7b6349f833f25027858b230?s=80&d=identicon&r=pg
+message: >+
+  this solution don't work for italian culture because the separator is ,
+
+  you must use en-GB culture
+


### PR DESCRIPTION
avatar: <img src="https://secure.gravatar.com/avatar/770aa719b7b6349f833f25027858b230?s=80&d=identicon&r=pg" width="64" height="64" />

this solution don't work for italian culture because the separator is ,
you must use en-GB culture
