### PR TITLE
Comment by Alessandro Lettieri on fixing-binding-to-decimals-aspx

### DIFF
--- a/_data/comments/fixing-binding-to-decimals-aspx/c45cdf51.yml
+++ b/_data/comments/fixing-binding-to-decimals-aspx/c45cdf51.yml
@@ -1,0 +1,10 @@
+id: c45cdf51
+date: 2018-08-09T09:42:46.7879500Z
+name: Alessandro Lettieri
+avatar: https://secure.gravatar.com/avatar/770aa719b7b6349f833f25027858b230?s=80&d=identicon&r=pg
+message: >-
+  You must bind also decimal nullable:
+
+
+
+      ModelBinders.Binders.Add(typeof(decimal?), new DecimalModelBinder());


### PR DESCRIPTION
avatar: <img src="https://secure.gravatar.com/avatar/770aa719b7b6349f833f25027858b230?s=80&d=identicon&r=pg" width="64" height="64" />

You must bind also decimal nullable:

    ModelBinders.Binders.Add(typeof(decimal?), new DecimalModelBinder());