### PR TITLE
Comment by Babak on i-knew-how-to-validate-an-email-address-until-i-aspx

### DIFF
--- a/_data/comments/i-knew-how-to-validate-an-email-address-until-i-aspx/79b574ca.yml
+++ b/_data/comments/i-knew-how-to-validate-an-email-address-until-i-aspx/79b574ca.yml
@@ -1,0 +1,5 @@
+id: 79b574ca
+date: 2018-08-26T04:59:03.6567870Z
+name: Babak
+avatar: https://secure.gravatar.com/avatar/cf6b905762dda1df8b5adedd0b2d022f?s=80&d=identicon&r=pg
+message: The validation fails on `a.example@gmx.ch' which it's a correct email address. Any idea?


### PR DESCRIPTION
avatar: <img src="https://secure.gravatar.com/avatar/cf6b905762dda1df8b5adedd0b2d022f?s=80&d=identicon&r=pg" width="64" height="64" />

The validation fails on `a.example@gmx.ch' which it's a correct email address. Any idea?