### PR TITLE
Comment by Martin on url-routing-debugger-aspx

### DIFF
--- a/_data/comments/url-routing-debugger-aspx/0f42cbfc.yml
+++ b/_data/comments/url-routing-debugger-aspx/0f42cbfc.yml
@@ -1,0 +1,5 @@
+id: 0f42cbfc
+date: 2018-10-04T12:43:21.3526229Z
+name: Martin
+avatar: https://secure.gravatar.com/avatar/36e80e7203558664ba9241881ee9744e?s=80&d=identicon&r=pg
+message: Seems like the zip files are not longer available in this article.... Any way to use the debugger without the route tester tool?


### PR DESCRIPTION
avatar: <img src="https://secure.gravatar.com/avatar/36e80e7203558664ba9241881ee9744e?s=80&d=identicon&r=pg" width="64" height="64" />

Seems like the zip files are not longer available in this article.... Any way to use the debugger without the route tester tool?