### PR TITLE
Fix header caching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem "github-pages", group: :jekyll_plugins
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.6"
   gem "jekyll-remote-theme"
+  gem "jekyll-include-cache"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,8 @@ GEM
     jekyll-github-metadata (2.9.4)
       jekyll (~> 3.1)
       octokit (~> 4.0, != 4.4.0)
+    jekyll-include-cache (0.1.0)
+      jekyll (~> 3.3)
     jekyll-mentions (1.4.1)
       html-pipeline (~> 2.3)
       jekyll (~> 3.0)
@@ -244,6 +246,8 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2018.7)
+      tzinfo (>= 1.0.0)
     unicode-display_width (1.4.0)
 
 PLATFORMS
@@ -254,6 +258,7 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   jekyll-feed (~> 0.6)
+  jekyll-include-cache
   jekyll-remote-theme
   minima (~> 2.0)
   tzinfo-data

--- a/_config.yml
+++ b/_config.yml
@@ -65,6 +65,10 @@ kramdown:
   hard_wrap: false
 remote_theme: haacked/haackbar
 
+exclude: [README.md CODE_OF_CONDUCT.md script .gitattributes .gitignore keybase.txt RakeFile]
+keep_files: [images demos code ads.txt robots.txt favicon.ico]
+incremental: true
+
 # Plugins
 plugins:
   - jekyll-seo-tag
@@ -73,3 +77,4 @@ plugins:
   - jekyll-redirect-from
   - jekyll-sitemap
   - jekyll-paginate
+  - jekyll-include-cache

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
-<html lang="{{ page.lang | default: site.lang | default: 'en' }}">
-  {% include head.html %}
+<html lang="en">
+  {% include_cached head.html %}
   <body>
-    <header class="header" class="inner">{% include header.html %}</header>
+    <header class="header" class="inner">{% include_cached header.html %}</header>
     <main class="page-content" aria-label="Content">
       <div class="wrapper">
         <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CK7DTK3L&placement=haackedcom" id="_carbonads_js"></script>
         {{ content }}
       </div>
-      {% include footer.html %}
+      {% include_cached footer.html %}
     </main>
   </body>
 


### PR DESCRIPTION
The header rendering no longer depends on the current page. It's the same for every page. The theme now selects the current page using JS. This cuts down build time from 390 seconds to 39 seconds!