### PR TITLE
Comment by David Cook on its-no-ipod-but-it-is-100gb-aspx

### DIFF
--- a/_data/comments/its-no-ipod-but-it-is-100gb-aspx/68985417.yml
+++ b/_data/comments/its-no-ipod-but-it-is-100gb-aspx/68985417.yml
@@ -1,0 +1,10 @@
+id: 68985417
+date: 2022-01-30T19:58:31.0687436Z
+name: David Cook
+avatar: https://secure.gravatar.com/avatar/ac55838a9449bfafc100d51d1644e97b?s=80&d=identicon&r=pg
+message: >-
+  I bought 2 DMC XClefs, both with 100GB hard drives, in 2005.
+
+  It is now 2022 and both of them still work fine, but the battery life for both is about an hour.  i've dropped each one now and then, and they still work.
+
+  The only IPod I've ever owned lasted about a year.


### PR DESCRIPTION
avatar: <img src="https://secure.gravatar.com/avatar/ac55838a9449bfafc100d51d1644e97b?s=80&d=identicon&r=pg" width="64" height="64" />

I bought 2 DMC XClefs, both with 100GB hard drives, in 2005.
It is now 2022 and both of them still work fine, but the battery life for both is about an hour.  i've dropped each one now and then, and they still work.
The only IPod I've ever owned lasted about a year.