### PR TITLE
Comment by Sean Killeen on calculating-mrr-with-stripe-and-csharp

### DIFF
--- a/_data/comments/calculating-mrr-with-stripe-and-csharp/2dabbcae.yml
+++ b/_data/comments/calculating-mrr-with-stripe-and-csharp/2dabbcae.yml
@@ -1,0 +1,14 @@
+id: 2dabbcae
+date: 2022-10-12T21:50:11.7939228Z
+name: Sean Killeen
+avatar: https://unavatar.now.sh/twitter/SeanKilleen.com/
+message: >-
+  Is this different than Stripe Metrics export? https://stripe.com/docs/billing/subscriptions/view-metrics#metrics-export
+
+
+
+  The metrics export includes MRR per subscriber per month and MRR roll-forward, active subscriber roll-forward, etc.
+
+
+
+  Regardless, this is a great walkthrough! And I agree, Stripe support is awesome.


### PR DESCRIPTION
avatar: <img src="https://unavatar.now.sh/twitter/SeanKilleen.com/" width="64" height="64" />

Is this different than Stripe Metrics export? https://stripe.com/docs/billing/subscriptions/view-metrics#metrics-export

The metrics export includes MRR per subscriber per month and MRR roll-forward, active subscriber roll-forward, etc.

Regardless, this is a great walkthrough! And I agree, Stripe support is awesome.