### PR TITLE
Comment by haacked on recover-from-dbupdate-exception

### DIFF
--- a/_data/comments/recover-from-dbupdate-exception/c3add191.yml
+++ b/_data/comments/recover-from-dbupdate-exception/c3add191.yml
@@ -1,0 +1,5 @@
+id: c3add191
+date: 2022-12-06T16:32:13.1605703Z
+name: haacked
+avatar: https://unavatar.now.sh/twitter/haacked/
+message: Thomas and Steve, you're absolutely correct! This is what happens when I try to transcribe code and simplify it for brevity. I just posted an update with the correct code. We want to query to a new variable. We only want to detach if we're going to recover.


### PR DESCRIPTION
avatar: <img src="https://unavatar.now.sh/twitter/haacked/" width="64" height="64" />

Thomas and Steve, you're absolutely correct! This is what happens when I try to transcribe code and simplify it for brevity. I just posted an update with the correct code. We want to query to a new variable. We only want to detach if we're going to recover.