### PR TITLE
Comment by haacked on recover-from-dbupdate-exception

### DIFF
--- a/_data/comments/recover-from-dbupdate-exception/b1bd39ea.yml
+++ b/_data/comments/recover-from-dbupdate-exception/b1bd39ea.yml
@@ -1,0 +1,10 @@
+id: b1bd39ea
+date: 2022-12-07T15:52:25.9284410Z
+name: haacked
+avatar: https://unavatar.now.sh/twitter/haacked/
+message: >-
+  > Why are allowing your repository method to be executed concurrently from multiple threads?
+
+
+
+  I'm not. The background task gets its own instance of DbContext injected. I'll explain this in a follow-up post.


### PR DESCRIPTION
avatar: <img src="https://unavatar.now.sh/twitter/haacked/" width="64" height="64" />

> Why are allowing your repository method to be executed concurrently from multiple threads?

I'm not. The background task gets its own instance of DbContext injected. I'll explain this in a follow-up post.