### PR TITLE
Comment by Zack Light on law-of-demeter-dot-counting-aspx

### DIFF
--- a/_data/comments/law-of-demeter-dot-counting-aspx/4040316c.yml
+++ b/_data/comments/law-of-demeter-dot-counting-aspx/4040316c.yml
@@ -1,0 +1,5 @@
+id: 4040316c
+date: 2023-06-22T05:01:23.8905479Z
+name: Zack Light
+avatar: https://github.com/Zackhardtoname.png
+message: It seems to me that LOD is especially useful/applicable if the object returned from an violation goes through various transformation such as the wallet example. However, if there are not any transformation logic, as in the UI & driver's license example. We could justify it by saying one of the chained objects serve as containers, and the violation is okay.


### PR DESCRIPTION
avatar: <img src="https://github.com/Zackhardtoname.png" width="64" height="64" />

It seems to me that LOD is especially useful/applicable if the object returned from an violation goes through various transformation such as the wallet example. However, if there are not any transformation logic, as in the UI & driver's license example. We could justify it by saying one of the chained objects serve as containers, and the violation is okay.