### PR TITLE
Comment by James on github-flow-aliases

### DIFF
--- a/_data/comments/github-flow-aliases/96ab5100.yml
+++ b/_data/comments/github-flow-aliases/96ab5100.yml
@@ -1,0 +1,5 @@
+id: 96ab5100
+date: 2024-03-26T14:23:03.2139642Z
+name: James
+avatar: https://robohash.org/7147b1fc151de120fbc956ba90be1d37
+message: 'To avoid "fatal: branch name required" add the --no-run-if-empty flag to xargs in bclean'


### PR DESCRIPTION
avatar: <img src="https://robohash.org/7147b1fc151de120fbc956ba90be1d37" width="64" height="64" />

To avoid "fatal: branch name required" add the --no-run-if-empty flag to xargs in bclean