### PR TITLE
Comment by Oskar Gewalli on dotnet-aspire-vs-docker

### DIFF
--- a/_data/comments/dotnet-aspire-vs-docker/9a47e441.yml
+++ b/_data/comments/dotnet-aspire-vs-docker/9a47e441.yml
@@ -1,0 +1,9 @@
+id: 9a47e441
+date: 2024-07-17T14:05:44.0672933Z
+name: Oskar Gewalli
+avatar: https://robohash.org/d41d8cd98f00b204e9800998ecf8427e
+message: >+
+  I get a 404 for this link 
+
+  https://github.com/haacked/docker-efcore-postgres-demo
+


### PR DESCRIPTION
avatar: <img src="https://robohash.org/d41d8cd98f00b204e9800998ecf8427e" width="64" height="64" />

I get a 404 for this link 
https://github.com/haacked/docker-efcore-postgres-demo
