### PR TITLE
Comment by Nat on comments-for-jekyll-blogs

### DIFF
--- a/_data/comments/comments-for-jekyll-blogs/b583e2e8.yml
+++ b/_data/comments/comments-for-jekyll-blogs/b583e2e8.yml
@@ -1,0 +1,5 @@
+id: b583e2e8
+date: 2024-11-01T21:03:24.2437245Z
+name: Nat
+avatar: https://github.com/Nataliagruber.png
+message: This looks interesting! One thing I find a little concerning is that it seems as if I van just put anyone's github name into the comment and it would display as if that person made the comment, which feels a bit too exploitable. I wonder if there's a way to unite this approach with something that requires a (github or otherwise) login?


### PR DESCRIPTION
avatar: <img src="https://github.com/Nataliagruber.png" width="64" height="64" />

This looks interesting! One thing I find a little concerning is that it seems as if I van just put anyone's github name into the comment and it would display as if that person made the comment, which feels a bit too exploitable. I wonder if there's a way to unite this approach with something that requires a (github or otherwise) login?