### PR TITLE
Comment by Itay Sagui on string-or-value

### DIFF
--- a/_data/comments/string-or-value/81084d2e.yml
+++ b/_data/comments/string-or-value/81084d2e.yml
@@ -1,0 +1,5 @@
+id: 81084d2e
+date: 2025-01-09T13:57:42.9551458Z
+name: Itay Sagui
+avatar: https://robohash.org/0f6e88746cb645d8e029fdd6d2eb3e63
+message: Would you suggest having such a type in the dotnet framework itself? And if not, why not?


### PR DESCRIPTION
avatar: <img src="https://robohash.org/0f6e88746cb645d8e029fdd6d2eb3e63" width="64" height="64" />

Would you suggest having such a type in the dotnet framework itself? And if not, why not?