### PR TITLE
Fix extension method to get a configuration section

### DIFF
--- a/_posts/2024/2024-07-18-better-config-sections.md
+++ b/_posts/2024/2024-07-18-better-config-sections.md
@@ -105,10 +105,10 @@ public static class OptionsExtensions {
         return builder;
     }
 
-    public static TOptions? GetConfigurationSection<TOptions>(this IHostApplicationBuilder builder)
+    public static TOptions? GetConfigurationSection<TOptions>(this IConfiguration configuration)
         where TOptions : class, IConfigOptions
     {
-        return builder.Configuration
+        return configuration
             .GetSection(TOptions.SectionName)
             .Get<TOptions>();
     }


### PR DESCRIPTION
This relates to:
>Sometimes, you’re in a situation where you can’t inject `IOptions<T>` for whatever reason. You can grab it from `IConfiguration` like so:
>```csharp
>Configuration.GetSection("OpenAI").Get<OpenAIOptions>()
>

In cases when you need to get a configuration section it is doubtful you'll do this by injecting `IHostApplicationBuilder`. Usually `IConfiguration` injection is enough