### PR TITLE
Add post: Sign Commits from Anywhere Without Your Keys Going Anywhere

### DIFF
--- a/.blog-config.sh.example
+++ b/.blog-config.sh.example
@@ -22,8 +22,9 @@ IMAGE_BASE_URL="https://i.haacked.com"
 # Leave empty to skip auto-opening
 EDITOR=""
 
-# DALL-E image generation settings
-DALLE_MODEL="dall-e-3"
-DALLE_SIZE="1024x1024"  # Options: 1024x1024, 1792x1024, 1024x1792
-DALLE_QUALITY="standard"  # Options: standard, hd
-DALLE_STYLE="vivid"  # Options: vivid, natural
+# OpenAI image generation settings
+# dall-e-3 was retired by OpenAI in 2026; gpt-image-1 is the replacement.
+DALLE_MODEL="gpt-image-1"
+DALLE_SIZE="1024x1024"  # Options: 1024x1024, 1536x1024, 1024x1536
+DALLE_QUALITY="high"  # Options: low, medium, high, auto
+DALLE_STYLE="vivid"  # Only used if DALLE_MODEL=dall-e-3. Options: vivid, natural

--- a/_posts/2026/2026-07-16-remote-commit-signing.md
+++ b/_posts/2026/2026-07-16-remote-commit-signing.md
@@ -1,0 +1,227 @@
+---
+title: "Sign Commits from Anywhere Without Your Keys Going Anywhere"
+description: "How I sign git commits with Secure Enclave keys while remoted into my main Mac from an iPad or a cheap laptop — using Secretive, SSH agent forwarding, and one well-placed symlink."
+tags: [git, security, ssh, productivity, dotfiles]
+excerpt_image: ""
+---
+
+These days, my main MacBook Pro does a lot of coding without me sitting in front of it. Claude Code churns through tasks in [worktrees](https://haacked.com/archive/2025/11/21/tree-me/) while I check in from wherever I happen to be — the couch with an iPad, or out and about with a cheaper MacBook that exists mostly to be a remote control for the expensive one. [Jump Desktop](https://jumpdesktop.com/) gives me a screen share, [Blink Shell](https://blink.sh/) gives me a terminal on the iPad, and the work just keeps going.
+
+There was one snag: signed commits.
+
+I sign all my commits, and my signing keys live in the Secure Enclave via [Secretive](https://github.com/maxgoedjen/secretive). That's great for security — the key physically cannot leave the machine. It's less great when git asks the Secure Enclave to sign a commit and the Secure Enclave asks for a Touch ID press from a person who is forty miles away from the keyboard.
+
+[image1: A person relaxing on a couch with an iPad, remotely controlling a MacBook on a desk in another room. A glowing padlock hovers over the MacBook. Cozy, slightly whimsical illustration style.]
+
+This post walks through the setup I landed on: I can be on my iPad or the cheap laptop, remote into the main Mac, and every commit — including ones made by a Claude Code session that's been running since morning — gets signed by a hardware-backed key, with the approval prompt appearing on the device in my hands.
+
+## Why Secretive instead of a key file?
+
+The traditional approach stores your SSH private key in a file like `~/.ssh/id_ed25519`. The problem is that it's just that: a file. Any process running as you can read it. A malicious npm package, a compromised build script, a sloppy backup — any of them can quietly copy your key, and once it's copied, it's gone. You won't even know. A passphrase helps less than you'd think, because the decrypted key ends up in ssh-agent's memory anyway, and you'll be typing that passphrase into enough prompts that you stop looking at them.
+
+Secretive generates keys *inside* the Secure Enclave, the same hardware security chip that guards Touch ID and Apple Pay. The private key never exists on disk, never exists in process memory, and cannot be exported — not by you, not by malware, not by anyone. When something wants a signature, it has to ask the enclave, and the enclave asks you for Touch ID or Apple Watch approval first.
+
+That flips the threat model. Malware on your machine can no longer steal the key; the best it can do is *request a signature*, and the unexpected approval prompt is the alarm bell. A stolen laptop or a copied home directory yields nothing usable. And because each machine's key is born in that machine's enclave and dies with it, "revoke the key for the laptop I sold" is a one-line change instead of a fire drill.
+
+The tradeoff is exactly the feature: the key can't leave the machine. Which brings us back to my problem.
+
+## The setup
+
+Each of my Macs has its own Secretive key. Git signs with SSH keys these days (no GPG ceremony required), so the base config is small:
+
+```ini
+[user]
+    localSigningKey = ~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/PublicKeys/<hash>.pub
+[gpg]
+    format = ssh
+[gpg "ssh"]
+    program = /usr/bin/ssh-keygen
+    allowedSignersFile = ~/.dotfiles/git/allowed_signers
+[commit]
+    gpgsign = true
+```
+
+The `allowed_signers` file maps my email addresses to every machine's public key, so any machine can verify commits signed by any other:
+
+```text
+haacked@gmail.com ecdsa-sha2-nistp256 AAAA… GitHub-Commit-Signing@secretive.HaackBook-Pro.local
+phil.h@posthog.com ecdsa-sha2-nistp256 AAAA… GitHub-Commit-Signing@secretive.HaackBook-Pro.local
+haacked@gmail.com ecdsa-sha2-nistp256 AAAA… GitHub-Signing-Key@secretive.Phils-MacBook-Pro.local
+…
+```
+
+Each public key is also registered on GitHub as a signing key, so GitHub shows the ✅ Verified badge no matter which machine did the signing.
+
+> [!NOTE]
+> That's `localSigningKey`, not `signingkey`. It's a custom config key, and the distinction matters — more on that in a moment.
+
+So far, so standard. Sitting at any one of these machines, `git commit` triggers a Touch ID prompt and produces a signed commit. The interesting part is what happens when nobody is sitting at the machine.
+
+## The problem with being remote
+
+When I remote into the main Mac, there are two ways in, and both break signing in their own way.
+
+**Screen sharing (Jump Desktop).** I'm looking at the Mac's actual desktop, driving its actual shells. When git commits, it asks the Mac's local Secretive for a signature, and Secretive pops a Touch ID prompt… on a laptop lid that may well be closed, in a room I'm not in. My iPad's screen share can show me the prompt, but it can't press a fingerprint through the glass.
+
+**SSH.** SSH has agent forwarding, which is *almost* the answer. With `ForwardAgent yes`, my client device's SSH agent — Secretive on the cheap MacBook, Blink's Secure Enclave-backed keys on the iPad — becomes reachable on the main Mac through a socket that sshd creates. Signature requests travel back over the SSH connection to the device in my hands, which is exactly what I want.
+
+But naive agent forwarding has three gaps:
+
+1. **The socket is per-session and mortal.** sshd puts it at a random path, exports it as `SSH_AUTH_SOCK` in that one session, and deletes it when the connection drops. Every other shell on the machine has no idea it exists.
+2. **Long-lived processes never see it.** A Claude Code session started this morning inherited whatever `SSH_AUTH_SOCK` existed this morning. It's not going to re-read my zshrc because I SSHed in after lunch. Neither is the shell inside the Jump Desktop screen share.
+3. **Git needs to know *which key* to ask for.** SSH signing isn't "sign with whatever the agent has" — git needs the specific public key. When I'm remote, the right key is the *client device's* key, not the Mac's. A key baked into git config is wrong half the time.
+
+I went looking for a way to remotely approve the Mac's own Secretive prompts, and there isn't one — Secretive's approval is deliberately local-only, which is the point of it. The answer isn't to weaken the Mac's key. It's to stop using the Mac's key when I'm not at the Mac, and use the key of the device I *am* at.
+
+## The trick: one symlink, zero cached state
+
+The whole system boils down to two decisions:
+
+1. There is exactly **one** stable agent path on the machine: `~/.ssh/agent.sock`, a symlink. Everything — shells, GUI apps, git — points at the symlink, and the symlink points at whichever real agent socket is currently alive.
+2. Git resolves the signing key **at the moment of signing**, not ahead of time. No cached key file, nothing to go stale.
+
+Everything else is plumbing to maintain those two invariants. Let's walk through the pieces; they all live in [my dotfiles](https://github.com/haacked/dotfiles/).
+
+### The symlink healer
+
+A small script, [`bin/ssh-agent-sync`](https://github.com/haacked/dotfiles/blob/main/bin/ssh-agent-sync), is the single source of truth for where the symlink points. Handed a live forwarded socket, it points the symlink there; otherwise, if the symlink is dangling, it heals back toward the local Secretive socket:
+
+```bash
+sock="$HOME/.ssh/agent.sock"
+secretive="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+forwarded="${1:-}"
+
+if [[ -n "$forwarded" && -S "$forwarded" ]]; then
+  [[ "$sock" -ef "$forwarded" ]] || ln -sf "$forwarded" "$sock"
+elif [[ ! -S "$sock" ]] && [[ -S "$secretive" ]]; then
+  ln -sf "$secretive" "$sock"
+fi
+
+if [[ -S "$sock" ]] && [[ "$sock" -ef "$secretive" ]]; then
+  echo "local"
+elif [[ -S "$sock" ]]; then
+  echo "forwarded"
+else
+  echo "none"
+fi
+```
+
+It's idempotent — it only touches the symlink when it isn't already pointing at the right target — and it reports which mode it resolved to (`local`, `forwarded`, or `none`) so callers don't have to re-derive that.
+
+### The shell hook
+
+My zshrc captures the forwarded socket and keeps the symlink synced. The subtle bits are *when* it captures and *how often* it syncs:
+
+```sh
+# Capture the sshd-provided socket once, at startup, before the first
+# sync overwrites SSH_AUTH_SOCK with the symlink path.
+[[ -n "$SSH_CONNECTION" ]] && _SSH_FWD_SOCK="$SSH_AUTH_SOCK"
+
+_ssh_agent_sync() {
+  "$HOME/.dotfiles/bin/ssh-agent-sync" "$_SSH_FWD_SOCK" >/dev/null
+  [[ -S "$HOME/.ssh/agent.sock" ]] && export SSH_AUTH_SOCK="$HOME/.ssh/agent.sock"
+}
+_ssh_agent_sync
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _ssh_agent_sync
+```
+
+The forwarded socket path has to be captured *before* the first sync, because after that `SSH_AUTH_SOCK` is the symlink — re-deriving "the forwarded socket" from it later would just compare the symlink against itself.
+
+And it re-syncs on every `precmd` — before each prompt — not just at shell startup. The symlink is shared machine-wide, so a local shell that was already running before my SSH session started will never source zshrc again when that session *ends*. Without the recheck, it would keep pointing at a forwarding socket sshd already tore down. Since `ssh-agent-sync` is idempotent, idle prompts don't pay for a redundant `ln`.
+
+Note what every shell exports: the *symlink*, never the raw socket. That's the indirection that makes long-lived sessions work. A Claude Code session started hours ago holds a path that never changes; what's on the other end of it does.
+
+### Resolving the key at sign time
+
+Here's where `localSigningKey` vs `signingkey` pays off. Git has an escape hatch: if `user.signingkey` is *unset*, git runs `gpg.ssh.defaultKeyCommand` to ask which key to use, fresh, on every signature:
+
+```ini
+[gpg "ssh"]
+    defaultKeyCommand = ~/.dotfiles/bin/git-signing-key
+```
+
+[`bin/git-signing-key`](https://github.com/haacked/dotfiles/blob/main/bin/git-signing-key) re-runs the healer, then answers based on what the symlink currently resolves to:
+
+```bash
+mode=$("$bin_dir/ssh-agent-sync") || mode="none"
+
+if [[ "$mode" == "forwarded" ]]; then
+  forwarded_key=$(SSH_AUTH_SOCK="$sock" ssh-add -L 2>/dev/null | head -1) || true
+  if [[ "$forwarded_key" == ssh-* || "$forwarded_key" == ecdsa-* || "$forwarded_key" == sk-* ]]; then
+    printf 'key::%s\n' "$forwarded_key"
+    exit 0
+  fi
+fi
+
+local_signing_key=$(git config --global --includes --get user.localSigningKey 2>/dev/null) || local_signing_key=""
+if [[ -n "$local_signing_key" && -f "$local_signing_key" ]]; then
+  printf 'key::%s\n' "$(cat "$local_signing_key")"
+  exit 0
+fi
+```
+
+If a forwarded agent is live, sign with whatever key it offers — that's the client device's Secure Enclave key. Otherwise, fall back to this machine's own Secretive key via `user.localSigningKey`. Since the decision happens at signing time, there's no cached state to go stale: whichever agent is alive when git signs is the one that gets asked.
+
+An earlier version of this setup cached the resolved key in a file that shell hooks kept up to date. It had a structural hole — anything that signed without a shell prompt having been drawn since the last agent transition (a background agent session, a GUI git client) would sign with a stale key or fail. Deleting the cache and resolving at use time made a whole category of bugs impossible.
+
+### GUI apps and everything that never sources zshrc
+
+One LaunchAgent seeds the environment for everything else at login:
+
+```xml
+<key>ProgramArguments</key>
+<array>
+    <string>/bin/sh</string>
+    <string>-c</string>
+    <string>"$HOME/.dotfiles/bin/ssh-agent-sync" >/dev/null && /bin/launchctl setenv SSH_AUTH_SOCK "$HOME/.ssh/agent.sock"</string>
+</array>
+<key>RunAtLoad</key>
+<true/>
+```
+
+`launchctl setenv` makes `SSH_AUTH_SOCK` visible to GUI apps and anything else that never runs my shell startup — and because it's set to the symlink, not a raw socket, those apps track agent transitions too, without ever knowing transitions happen.
+
+### The SSH client side
+
+The last piece is the client config, which is refreshingly boring:
+
+```text
+Host phils-macbook-pro macbook
+    HostName 100.x.y.z
+    ForwardAgent yes
+
+Host *
+    IdentityAgent "~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+```
+
+The IP is a [Tailscale](https://tailscale.com/) address, so `ssh macbook` works from anywhere without exposing sshd to the internet. `ForwardAgent yes` does the forwarding; `IdentityAgent` points outbound SSH at Secretive so the *authentication* to the Mac is also enclave-backed. On the iPad, Blink Shell does the equivalent: its keys are Secure Enclave-backed with biometric unlock, and it forwards its agent.
+
+## What it looks like in practice
+
+From the iPad or the cheap MacBook: `ssh macbook`. Tmux auto-attaches to my persistent session, and — this is the part I love — from that moment, *the entire machine* is signing through the device in my hands. The SSH session, sure. But also the Jump Desktop screen share I have open next to it, and the Claude Code session that's been grinding away since breakfast. They all hold the same symlink, and the symlink now points at the forwarded agent.
+
+When any of them commits, the approval prompt appears right here: Touch ID on the MacBook Neo, Face ID via Blink on the iPad. I approve it from the couch. The commit is signed by *this* device's Secure Enclave key — a different key than the main Mac would use, but `allowed_signers` and GitHub both know all my keys, so every commit verifies the same.
+
+When I close the connection, the next shell prompt on the Mac notices the dead socket and heals the symlink back to local Secretive. Sit down at the desk, and Touch ID works like nothing ever happened. No mode switch, no config to flip. The system doesn't have a "remote mode" — it just has a symlink that always points at the truth.
+
+## Caveats
+
+**Agent forwarding is a trust decision.** A forwarded agent means root (and you) on the host can send signature requests to your client's agent. Forwarding into a box you don't control is how people get their keys borrowed. Here I'm forwarding into my own Mac over my own tailnet, and every request still requires biometric approval on the client, so I sleep fine — but I wouldn't `ForwardAgent yes` to a shared server.
+
+**Pure screen share can't sign unattended.** If there's no live SSH connection, the symlink points at the Mac's local Secretive, and that still wants a human at the machine. Usually the fix is one `ssh macbook` from whatever device I'm holding. For the rare case where even that's not an option, the escape hatch is `git commit --no-gpg-sign` now and a batch re-sign later:
+
+```ini
+[alias]
+    sign-unpushed = "!f() { DEFAULT=$(git default); UPSTREAM=${1-origin/$DEFAULT}; git rebase --exec \"git commit --amend --no-edit -S\" $UPSTREAM; }; f"
+```
+
+`git sign-unpushed` rebases the unpushed commits, re-signing each one — a satisfying little drumroll of Touch ID prompts when I'm back at the desk.
+
+## Wrap up
+
+The security posture here is the part I'd underline: at no point does any private key exist as a file, on any machine, ever. Each device has its own key sealed in its own Secure Enclave, every signature requires a biometric approval on a device in my physical possession, and losing any single device revokes exactly one key.
+
+And the ergonomics didn't pay for it. Claude Code works on the big machine; I supervise from whatever slab of glass is nearby; commits come out signed and verified. The whole thing is a couple of small scripts, a symlink, and one underappreciated git config setting.
+
+Everything is in my [dotfiles repo](https://github.com/haacked/dotfiles/) — `bin/ssh-agent-sync`, `bin/git-signing-key`, the zshrc hook, and the LaunchAgent — if you want to steal it. That's what dotfiles are for.

--- a/_posts/2026/2026-07-16-remote-commit-signing.md
+++ b/_posts/2026/2026-07-16-remote-commit-signing.md
@@ -23,6 +23,9 @@ Secretive generates keys inside the Secure Enclave, the same hardware chip that 
 
 That changes the threat model. Malware can't steal a key it can't read. The best it can do is request a signature, and an unexpected approval prompt is a pretty good alarm bell. A stolen laptop yields nothing usable. And since each machine's key lives and dies in that machine's enclave, revoking the key for a laptop I sold is a one-line change instead of a fire drill.
 
+> [!IMPORTANT]
+> That alarm bell only rings if you check "Requires Authentication" when you create the key in Secretive. You can't change it later, only create a new key. Without it, the enclave signs silently for any process running as you, which quietly deletes most of the benefit described above. Relatedly, when Secretive prompts you, it offers to persist the approval for a period of time. During that window, signing is silent too. Keep it short.
+
 The tradeoff is the same as the feature: the key can't leave the machine. Which brings us back to my problem.
 
 ## The Setup
@@ -61,7 +64,7 @@ So far, so standard. Sitting at any one of these machines, `git commit` triggers
 
 When I remote into the main Mac, there are two ways in, and both break signing in their own way.
 
-**Screen sharing (Jump Desktop)**: I'm looking at the Mac's actual desktop, driving its actual shells. When git commits, it asks the Mac's local Secretive for a signature, and Secretive pops a Touch ID prompt on a laptop that may well have its lid closed, in a room I'm not in. My iPad can show me the prompt. It can't press a fingerprint through the glass, no matter how sincerely I tap it.
+**Screen sharing (Jump Desktop)**: I'm looking at the Mac's actual desktop, driving its actual shells. When git commits, it asks the Mac's local Secretive for a signature, and Secretive pops a Touch ID prompt on a laptop that may well have its lid closed, in a room I'm not in. My iPad can show me the prompt. It can't press a fingerprint through the glass, no matter how hard I tap it.
 
 **SSH**: SSH has agent forwarding, which is almost the answer. With `ForwardAgent yes`, my client device's SSH agent (Secretive on the cheap MacBook, Blink's Secure Enclave keys on the iPad) becomes reachable on the main Mac through a socket that sshd creates. Signature requests travel back over the SSH connection to the device in my hands, which is exactly what I want.
 
@@ -201,7 +204,7 @@ The IP is a [Tailscale](https://tailscale.com/) address, so `ssh macbook` works 
 
 From the iPad or the cheap MacBook: `ssh macbook`. Tmux auto-attaches to my persistent session, and from that moment the entire machine signs through the device in my hands. The SSH session, sure. But also the Jump Desktop screen share I have open next to it, and the Claude Code session that's been grinding away since breakfast. They all hold the same symlink, and the symlink now points at the forwarded agent.
 
-When any of them commits, the approval prompt appears right here. Touch ID on the cheap MacBook. Face ID via Blink on the iPad. The commit gets signed with this device's key, which is a different key than the main Mac would use, but `allowed_signers` and GitHub know all my keys, so every commit verifies the same.
+When any of them commits, the approval prompt appears right here. Touch ID on the MacBook Neo. Face ID via Blink on the iPad. The commit gets signed with this device's key, which is a different key than the main Mac would use, but `allowed_signers` and GitHub know all my keys, so every commit verifies the same.
 
 When I close the connection, the next shell prompt on the Mac notices the dead socket and heals the symlink back to local Secretive. I sit down at the desk and Touch ID works like nothing happened. There's no remote mode to toggle, just a symlink that points at whatever agent is currently real.
 

--- a/_posts/2026/2026-07-16-remote-commit-signing.md
+++ b/_posts/2026/2026-07-16-remote-commit-signing.md
@@ -17,11 +17,11 @@ This post walks through the setup I landed on. I can be on my iPad or the cheap 
 
 ## Why Secretive Instead of a Key File?
 
-The traditional approach stores your SSH private key in a file like `~/.ssh/id_ed25519`. The problem is that it's just that: a file. Any process running as you can read it. A malicious npm package can quietly copy it. So can a compromised build script or a sloppy backup. Once it's copied, it's gone, and you won't even know. A passphrase helps less than you'd think because the decrypted key sits in ssh-agent's memory anyway. Besides, you type that passphrase into enough prompts that you eventually stop looking at them.
+The traditional approach stores your SSH private key in a file like `~/.ssh/id_ed25519`. The problem is that it's a file. Any process running as you can read it. A malicious npm package can quietly copy it. So can a compromised build script or a sloppy backup. Once it's copied, it's gone, and you won't even know. A passphrase helps less than you'd think because the decrypted key sits in ssh-agent's memory anyway. Besides, you type that passphrase into enough prompts that you eventually stop looking at them. I certainly did.
 
-Secretive generates keys inside the Secure Enclave, the same hardware chip that guards Touch ID and Apple Pay. The private key never exists on disk or in process memory, and there's no export button. Not even for you. When something wants a signature, it has to ask the enclave, and the enclave asks you for Touch ID or Apple Watch approval first.
+Secretive generates keys inside the Secure Enclave, the same hardware chip that guards Touch ID and Apple Pay. The private key never exists on disk or in process memory, and there's no export button, even for you. When something wants a signature, it has to ask the enclave, and the enclave asks you for Touch ID or Apple Watch approval first.
 
-That changes the threat model. Malware can't steal a key it can't read. The best it can do is request a signature, and an unexpected approval prompt is a pretty good alarm bell. A stolen laptop yields nothing usable. And since each machine's key is born in that machine's enclave and dies with it, revoking the key for a laptop I sold is a one-line change instead of a fire drill.
+That changes the threat model. Malware can't steal a key it can't read. The best it can do is request a signature, and an unexpected approval prompt is a pretty good alarm bell. A stolen laptop yields nothing usable. And since each machine's key lives and dies in that machine's enclave, revoking the key for a laptop I sold is a one-line change instead of a fire drill.
 
 The tradeoff is the same as the feature: the key can't leave the machine. Which brings us back to my problem.
 
@@ -63,7 +63,7 @@ When I remote into the main Mac, there are two ways in, and both break signing i
 
 **Screen sharing (Jump Desktop)**: I'm looking at the Mac's actual desktop, driving its actual shells. When git commits, it asks the Mac's local Secretive for a signature, and Secretive pops a Touch ID prompt on a laptop that may well have its lid closed, in a room I'm not in. My iPad can show me the prompt. It can't press a fingerprint through the glass.
 
-**SSH**: SSH has agent forwarding, which is almost the answer. With `ForwardAgent yes`, my client device's SSH agent (Secretive on the cheap MacBook, Blink's Secure Enclave keys on the iPad) becomes reachable on the main Mac through a socket that sshd creates. Signature requests travel back over the SSH connection to the device in my hands. That's exactly what I want.
+**SSH**: SSH has agent forwarding, which is almost the answer. With `ForwardAgent yes`, my client device's SSH agent (Secretive on the cheap MacBook, Blink's Secure Enclave keys on the iPad) becomes reachable on the main Mac through a socket that sshd creates. Signature requests travel back over the SSH connection to the device in my hands, which is exactly what I want.
 
 But naive agent forwarding has three gaps:
 
@@ -71,7 +71,7 @@ But naive agent forwarding has three gaps:
 2. **Long-lived processes never see it.** A Claude Code session started this morning inherited whatever `SSH_AUTH_SOCK` existed this morning. It's not going to re-read my zshrc because I SSHed in after lunch. Neither is the shell inside the Jump Desktop screen share.
 3. **Git needs to know which key to ask for.** SSH signing requires the specific public key up front. When I'm remote, the right key is the client device's key, not the Mac's. A key baked into git config is wrong half the time.
 
-I went looking for a way to remotely approve the Mac's own Secretive prompts. There isn't one. Secretive's approval is deliberately local-only, which is kind of the whole point of it. So instead of trying to weaken the Mac's key, I stopped using the Mac's key when I'm not at the Mac. Sign with the key of the device I'm actually touching.
+I went looking for a way to remotely approve the Mac's own Secretive prompts. There isn't one. Secretive's approval is deliberately local-only, which is kind of the whole point of it. So instead of trying to weaken the Mac's key, I stopped using the Mac's key when I'm not at the Mac and started signing with the key of the device I'm actually touching.
 
 ## One Symlink, Zero Cached State
 
@@ -130,7 +130,7 @@ The forwarded socket path has to be captured before the first sync. After that, 
 
 It also re-syncs on every `precmd`, not just at shell startup. The symlink is shared machine-wide, and a local shell that was running before my SSH session started will never source zshrc again when that session ends. Without the recheck, that shell would keep pointing at a forwarding socket sshd already tore down. Since the healer is idempotent, idle prompts don't pay for a redundant `ln`.
 
-Notice that every shell exports the symlink, never the raw socket. That's the indirection that makes long-lived sessions work. A Claude Code session started hours ago holds a path that never changes. What's on the other end of it does.
+Notice that every shell exports the symlink, never the raw socket. That's the indirection that makes long-lived sessions work. A Claude Code session started hours ago holds a path that never changes, even though what's on the other end of it comes and goes.
 
 ### Resolving the Key at Sign Time
 
@@ -203,7 +203,17 @@ From the iPad or the cheap MacBook: `ssh macbook`. Tmux auto-attaches to my pers
 
 When any of them commits, the approval prompt appears right here. Touch ID on the cheap MacBook. Face ID via Blink on the iPad. The commit gets signed with this device's key, which is a different key than the main Mac would use, but `allowed_signers` and GitHub know all my keys, so every commit verifies the same.
 
-When I close the connection, the next shell prompt on the Mac notices the dead socket and heals the symlink back to local Secretive. I sit down at the desk and Touch ID works like nothing happened. There's no remote mode to toggle. Just a symlink that points at whatever agent is real right now.
+When I close the connection, the next shell prompt on the Mac notices the dead socket and heals the symlink back to local Secretive. I sit down at the desk and Touch ID works like nothing happened. There's no remote mode to toggle, just a symlink that points at whatever agent is currently real.
+
+## How It Bit Me
+
+Not long after I drafted this post, signing started failing on me. Sometimes the approval prompt showed up on the device in my hands like it should. Other times git would sit there waiting on an approval that never came, because the Touch ID prompt was on the Mac's screen in a room I wasn't in.
+
+The culprit was me.
+
+At some point I had typed `ssh macbook` inside a tmux pane that was already on the main Mac. Every tmux pane looks the same, and I thought I was on the other laptop. So the Mac ssh'd into itself, forwarded its own Secretive agent back to itself, and the shell hook in that nested session adopted the looped socket as if it were a genuine forwarded agent. From then on, the machine believed it was remote. Every signature request went out through the "forwarded" socket and arrived right back at the local Secretive, which wanted a Touch ID press at a desk nobody was sitting at. Meanwhile my actual remote session held a perfectly good forwarded agent that nothing was using.
+
+The fix has two parts, both in the dotfiles now. The SSH config disables agent forwarding when the destination is the machine you're already on. And `ssh-agent-sync` compares a new forwarded socket's key list against the local Secretive's before adopting it. An exact match means it's a loop, and the script treats it as local.
 
 ## Caveats
 

--- a/_posts/2026/2026-07-16-remote-commit-signing.md
+++ b/_posts/2026/2026-07-16-remote-commit-signing.md
@@ -5,7 +5,7 @@ tags: [git, security, ssh, productivity, dotfiles]
 excerpt_image: ""
 ---
 
-These days, my main MacBook Pro does a lot of coding without me sitting in front of it. Claude Code churns through tasks in [worktrees](https://haacked.com/archive/2025/11/21/tree-me/) while I check in from wherever I happen to be. Sometimes that's the couch with an iPad. Sometimes it's a cheaper MacBook that exists mostly to be a remote control for the expensive one. [Jump Desktop](https://jumpdesktop.com/) gives me a screen share, [Blink Shell](https://blink.sh/) gives me a terminal on the iPad, and the work keeps going.
+These days, my main MacBook Pro does a lot of coding without me sitting in front of it. Claude Code churns through tasks in [worktrees](https://haacked.com/archive/2025/11/21/tree-me/) while I check in from wherever I happen to be. Sometimes that's the couch with an iPad. Sometimes it's a cheaper MacBook that exists mostly to be a remote control for the expensive one. I've essentially been promoted to middle management of my own computer. [Jump Desktop](https://jumpdesktop.com/) gives me a screen share, [Blink Shell](https://blink.sh/) gives me a terminal on the iPad, and the work keeps going whether I'm there or not.
 
 There was one snag: signed commits.
 
@@ -19,7 +19,7 @@ This post walks through the setup I landed on. I can be on my iPad or the cheap 
 
 The traditional approach stores your SSH private key in a file like `~/.ssh/id_ed25519`. The problem is that it's a file. Any process running as you can read it. A malicious npm package can quietly copy it. So can a compromised build script or a sloppy backup. Once it's copied, it's gone, and you won't even know. A passphrase helps less than you'd think because the decrypted key sits in ssh-agent's memory anyway. Besides, you type that passphrase into enough prompts that you eventually stop looking at them. I certainly did.
 
-Secretive generates keys inside the Secure Enclave, the same hardware chip that guards Touch ID and Apple Pay. The private key never exists on disk or in process memory, and there's no export button, even for you. When something wants a signature, it has to ask the enclave, and the enclave asks you for Touch ID or Apple Watch approval first.
+Secretive generates keys inside the Secure Enclave, the same hardware chip that guards Touch ID and Apple Pay. The private key never exists on disk or in process memory, and there's no export button, even for you. When something wants a signature, it has to ask the enclave, and the enclave asks you for Touch ID or Apple Watch approval first. The enclave trusts nobody, which I respect.
 
 That changes the threat model. Malware can't steal a key it can't read. The best it can do is request a signature, and an unexpected approval prompt is a pretty good alarm bell. A stolen laptop yields nothing usable. And since each machine's key lives and dies in that machine's enclave, revoking the key for a laptop I sold is a one-line change instead of a fire drill.
 
@@ -61,7 +61,7 @@ So far, so standard. Sitting at any one of these machines, `git commit` triggers
 
 When I remote into the main Mac, there are two ways in, and both break signing in their own way.
 
-**Screen sharing (Jump Desktop)**: I'm looking at the Mac's actual desktop, driving its actual shells. When git commits, it asks the Mac's local Secretive for a signature, and Secretive pops a Touch ID prompt on a laptop that may well have its lid closed, in a room I'm not in. My iPad can show me the prompt. It can't press a fingerprint through the glass.
+**Screen sharing (Jump Desktop)**: I'm looking at the Mac's actual desktop, driving its actual shells. When git commits, it asks the Mac's local Secretive for a signature, and Secretive pops a Touch ID prompt on a laptop that may well have its lid closed, in a room I'm not in. My iPad can show me the prompt. It can't press a fingerprint through the glass, no matter how sincerely I tap it.
 
 **SSH**: SSH has agent forwarding, which is almost the answer. With `ForwardAgent yes`, my client device's SSH agent (Secretive on the cheap MacBook, Blink's Secure Enclave keys on the iPad) becomes reachable on the main Mac through a socket that sshd creates. Signature requests travel back over the SSH connection to the device in my hands, which is exactly what I want.
 
@@ -211,7 +211,7 @@ Not long after I drafted this post, signing started failing on me. Sometimes the
 
 The culprit was me.
 
-At some point I had typed `ssh macbook` inside a tmux pane that was already on the main Mac. Every tmux pane looks the same, and I thought I was on the other laptop. So the Mac ssh'd into itself, forwarded its own Secretive agent back to itself, and the shell hook in that nested session adopted the looped socket as if it were a genuine forwarded agent. From then on, the machine believed it was remote. Every signature request went out through the "forwarded" socket and arrived right back at the local Secretive, which wanted a Touch ID press at a desk nobody was sitting at. Meanwhile my actual remote session held a perfectly good forwarded agent that nothing was using.
+At some point I had typed `ssh macbook` inside a tmux pane that was already on the main Mac. Every tmux pane looks exactly like every other tmux pane, and I thought I was on the other laptop. Reader, I was not. So the Mac ssh'd into itself, forwarded its own Secretive agent back to itself, and the shell hook in that nested session adopted the looped socket as if it were a genuine forwarded agent. From then on, the machine believed it was remote. My Mac was having an out-of-body experience, and my commits were paying for it. Every signature request went out through the "forwarded" socket and arrived right back at the local Secretive, which wanted a Touch ID press at a desk nobody was sitting at. Meanwhile my actual remote session held a perfectly good forwarded agent that nothing was using.
 
 The fix has two parts, both in the dotfiles now. The SSH config disables agent forwarding when the destination is the machine you're already on. And `ssh-agent-sync` compares a new forwarded socket's key list against the local Secretive's before adopting it. An exact match means it's a loop, and the script treats it as local.
 
@@ -232,6 +232,6 @@ The fix has two parts, both in the dotfiles now. The SSH config disables agent f
 
 At no point in any of this does a private key exist as a file. Each device has its own key sealed in its own Secure Enclave. Every signature requires a biometric approval on a device I'm physically touching. Losing a device revokes exactly one key.
 
-And I didn't give up anything to get here. Claude Code works on the big machine, I supervise from whatever screen is nearby, and commits come out signed and verified. The whole thing is two small scripts, a symlink, and one underappreciated git config setting.
+And I didn't give up anything to get here. Claude Code works on the big machine, I supervise from whatever screen is nearby, and commits come out signed and verified. The whole thing is two small scripts, a symlink, and one underappreciated git config setting. The symlink is doing most of the work, which feels right for a technology from 1983.
 
 Everything is in my [dotfiles repo](https://github.com/haacked/dotfiles/): `bin/ssh-agent-sync`, `bin/git-signing-key`, the zshrc hook, and the LaunchAgent. That's what dotfiles are for.

--- a/_posts/2026/2026-07-16-remote-commit-signing.md
+++ b/_posts/2026/2026-07-16-remote-commit-signing.md
@@ -5,11 +5,11 @@ tags: [git, security, ssh, productivity, dotfiles]
 excerpt_image: ""
 ---
 
-These days, my main MacBook Pro does a lot of coding without me sitting in front of it. Claude Code churns through tasks in [worktrees](https://haacked.com/archive/2025/11/21/tree-me/) while I check in from wherever I happen to be. Sometimes that's the couch with an iPad. Sometimes it's a cheaper MacBook that exists mostly to be a remote control for the expensive one. I've essentially been promoted to middle management of my own computer. [Jump Desktop](https://jumpdesktop.com/) gives me a screen share, [Blink Shell](https://blink.sh/) gives me a terminal on the iPad, and the work keeps going whether I'm there or not.
+These days, my main MacBook Pro does most of its coding without me. I mostly show up for the credit. For example, every day I walk with my daughter to a coffee shop while Claude Code churns through tasks in [worktrees](https://haacked.com/archive/2025/11/21/tree-me/). At the coffee shop, I'll remote in on a cheap MacBook Neo (upgraded from an iPad) to continue working. It's pretty much just a remote control for my main MacBook. [Jump Desktop](https://jumpdesktop.com/) gives me a screen share, [Blink Shell](https://blink.sh/) gives me a terminal on the iPad, and the work keeps going whether I'm there or not.
 
 There was one snag: signed commits.
 
-I sign all my commits, and my signing keys live in the Secure Enclave via [Secretive](https://github.com/maxgoedjen/secretive). That's great for security. The key physically cannot leave the machine. It's less great when git asks the Secure Enclave to sign a commit and the Secure Enclave asks for a Touch ID press from a person who is forty miles away from the keyboard.
+I sign all my commits, and my signing keys live in [the Secure Enclave](https://support.apple.com/guide/security/the-secure-enclave-sec59b0b31ff/web) via [Secretive](https://github.com/maxgoedjen/secretive). That's great for security. The key physically cannot leave the machine. It's less great when git asks the Secure Enclave to sign a commit and the Secure Enclave asks for a Touch ID press from a person who is forty miles away from the keyboard.
 
 [image1: A person relaxing on a couch with an iPad, remotely controlling a MacBook on a desk in another room. A glowing padlock hovers over the MacBook. Cozy, slightly whimsical illustration style.]
 
@@ -17,7 +17,7 @@ This post walks through the setup I landed on. I can be on my iPad or the cheap 
 
 ## Why Secretive Instead of a Key File?
 
-The traditional approach stores your SSH private key in a file like `~/.ssh/id_ed25519`. The problem is that it's a file. Any process running as you can read it. A malicious npm package can quietly copy it. So can a compromised build script or a sloppy backup. Once it's copied, it's gone, and you won't even know. A passphrase helps less than you'd think because the decrypted key sits in ssh-agent's memory anyway. Besides, you type that passphrase into enough prompts that you eventually stop looking at them. I certainly did.
+The traditional approach stores your SSH private key in a file like `~/.ssh/id_ed25519`. The problem is that it's a file. Any process running as you can read it. A malicious npm package can quietly copy it. So can a compromised build script or a sloppy backup. Once it's copied, it's gone, and you won't even know. A passphrase helps less than you'd think because the decrypted key sits in ssh-agent's memory anyway. Besides, you type that passphrase into enough prompts that you eventually stop looking at them.
 
 Secretive generates keys inside the Secure Enclave, the same hardware chip that guards Touch ID and Apple Pay. The private key never exists on disk or in process memory, and there's no export button, even for you. When something wants a signature, it has to ask the enclave, and the enclave asks you for Touch ID or Apple Watch approval first. The enclave trusts nobody, which I respect.
 
@@ -55,7 +55,7 @@ Each public key is also registered on GitHub as a signing key, so GitHub shows t
 > [!NOTE]
 > That's `localSigningKey`, not `signingkey`. It's a custom config key I made up, and the difference matters. More on that in a moment.
 
-So far, so standard. Sitting at any one of these machines, `git commit` triggers a Touch ID prompt and produces a signed commit. The interesting part is what happens when nobody is sitting at the machine.
+So far, so standard. Sitting at any one of these machines, `git commit` triggers a Touch ID prompt (or on my MacBook Neo, which lacks Touch ID, a double-click on my Apple Watch) and produces a signed commit. The interesting part is what happens when nobody is sitting at the machine.
 
 ## The Problem with Being Remote
 

--- a/_posts/2026/2026-07-16-remote-commit-signing.md
+++ b/_posts/2026/2026-07-16-remote-commit-signing.md
@@ -1,31 +1,31 @@
 ---
 title: "Sign Commits from Anywhere Without Your Keys Going Anywhere"
-description: "How I sign git commits with Secure Enclave keys while remoted into my main Mac from an iPad or a cheap laptop — using Secretive, SSH agent forwarding, and one well-placed symlink."
+description: "How I sign git commits with Secure Enclave keys while remoted into my main Mac from an iPad or a cheap laptop. All it takes is Secretive, SSH agent forwarding, and one well-placed symlink."
 tags: [git, security, ssh, productivity, dotfiles]
 excerpt_image: ""
 ---
 
-These days, my main MacBook Pro does a lot of coding without me sitting in front of it. Claude Code churns through tasks in [worktrees](https://haacked.com/archive/2025/11/21/tree-me/) while I check in from wherever I happen to be — the couch with an iPad, or out and about with a cheaper MacBook that exists mostly to be a remote control for the expensive one. [Jump Desktop](https://jumpdesktop.com/) gives me a screen share, [Blink Shell](https://blink.sh/) gives me a terminal on the iPad, and the work just keeps going.
+These days, my main MacBook Pro does a lot of coding without me sitting in front of it. Claude Code churns through tasks in [worktrees](https://haacked.com/archive/2025/11/21/tree-me/) while I check in from wherever I happen to be. Sometimes that's the couch with an iPad. Sometimes it's a cheaper MacBook that exists mostly to be a remote control for the expensive one. [Jump Desktop](https://jumpdesktop.com/) gives me a screen share, [Blink Shell](https://blink.sh/) gives me a terminal on the iPad, and the work keeps going.
 
 There was one snag: signed commits.
 
-I sign all my commits, and my signing keys live in the Secure Enclave via [Secretive](https://github.com/maxgoedjen/secretive). That's great for security — the key physically cannot leave the machine. It's less great when git asks the Secure Enclave to sign a commit and the Secure Enclave asks for a Touch ID press from a person who is forty miles away from the keyboard.
+I sign all my commits, and my signing keys live in the Secure Enclave via [Secretive](https://github.com/maxgoedjen/secretive). That's great for security. The key physically cannot leave the machine. It's less great when git asks the Secure Enclave to sign a commit and the Secure Enclave asks for a Touch ID press from a person who is forty miles away from the keyboard.
 
 [image1: A person relaxing on a couch with an iPad, remotely controlling a MacBook on a desk in another room. A glowing padlock hovers over the MacBook. Cozy, slightly whimsical illustration style.]
 
-This post walks through the setup I landed on: I can be on my iPad or the cheap laptop, remote into the main Mac, and every commit — including ones made by a Claude Code session that's been running since morning — gets signed by a hardware-backed key, with the approval prompt appearing on the device in my hands.
+This post walks through the setup I landed on. I can be on my iPad or the cheap laptop, remote into the main Mac, and every commit gets signed by a hardware-backed key. Even commits made by a Claude Code session that's been running since morning. The approval prompt shows up on the device in my hands.
 
-## Why Secretive instead of a key file?
+## Why Secretive Instead of a Key File?
 
-The traditional approach stores your SSH private key in a file like `~/.ssh/id_ed25519`. The problem is that it's just that: a file. Any process running as you can read it. A malicious npm package, a compromised build script, a sloppy backup — any of them can quietly copy your key, and once it's copied, it's gone. You won't even know. A passphrase helps less than you'd think, because the decrypted key ends up in ssh-agent's memory anyway, and you'll be typing that passphrase into enough prompts that you stop looking at them.
+The traditional approach stores your SSH private key in a file like `~/.ssh/id_ed25519`. The problem is that it's just that: a file. Any process running as you can read it. A malicious npm package can quietly copy it. So can a compromised build script or a sloppy backup. Once it's copied, it's gone, and you won't even know. A passphrase helps less than you'd think because the decrypted key sits in ssh-agent's memory anyway. Besides, you type that passphrase into enough prompts that you eventually stop looking at them.
 
-Secretive generates keys *inside* the Secure Enclave, the same hardware security chip that guards Touch ID and Apple Pay. The private key never exists on disk, never exists in process memory, and cannot be exported — not by you, not by malware, not by anyone. When something wants a signature, it has to ask the enclave, and the enclave asks you for Touch ID or Apple Watch approval first.
+Secretive generates keys inside the Secure Enclave, the same hardware chip that guards Touch ID and Apple Pay. The private key never exists on disk or in process memory, and there's no export button. Not even for you. When something wants a signature, it has to ask the enclave, and the enclave asks you for Touch ID or Apple Watch approval first.
 
-That flips the threat model. Malware on your machine can no longer steal the key; the best it can do is *request a signature*, and the unexpected approval prompt is the alarm bell. A stolen laptop or a copied home directory yields nothing usable. And because each machine's key is born in that machine's enclave and dies with it, "revoke the key for the laptop I sold" is a one-line change instead of a fire drill.
+That changes the threat model. Malware can't steal a key it can't read. The best it can do is request a signature, and an unexpected approval prompt is a pretty good alarm bell. A stolen laptop yields nothing usable. And since each machine's key is born in that machine's enclave and dies with it, revoking the key for a laptop I sold is a one-line change instead of a fire drill.
 
-The tradeoff is exactly the feature: the key can't leave the machine. Which brings us back to my problem.
+The tradeoff is the same as the feature: the key can't leave the machine. Which brings us back to my problem.
 
-## The setup
+## The Setup
 
 Each of my Macs has its own Secretive key. Git signs with SSH keys these days (no GPG ceremony required), so the base config is small:
 
@@ -50,41 +50,41 @@ haacked@gmail.com ecdsa-sha2-nistp256 AAAA… GitHub-Signing-Key@secretive.Phils
 …
 ```
 
-Each public key is also registered on GitHub as a signing key, so GitHub shows the ✅ Verified badge no matter which machine did the signing.
+Each public key is also registered on GitHub as a signing key, so GitHub shows the Verified badge no matter which machine did the signing.
 
 > [!NOTE]
-> That's `localSigningKey`, not `signingkey`. It's a custom config key, and the distinction matters — more on that in a moment.
+> That's `localSigningKey`, not `signingkey`. It's a custom config key I made up, and the difference matters. More on that in a moment.
 
 So far, so standard. Sitting at any one of these machines, `git commit` triggers a Touch ID prompt and produces a signed commit. The interesting part is what happens when nobody is sitting at the machine.
 
-## The problem with being remote
+## The Problem with Being Remote
 
 When I remote into the main Mac, there are two ways in, and both break signing in their own way.
 
-**Screen sharing (Jump Desktop).** I'm looking at the Mac's actual desktop, driving its actual shells. When git commits, it asks the Mac's local Secretive for a signature, and Secretive pops a Touch ID prompt… on a laptop lid that may well be closed, in a room I'm not in. My iPad's screen share can show me the prompt, but it can't press a fingerprint through the glass.
+**Screen sharing (Jump Desktop)**: I'm looking at the Mac's actual desktop, driving its actual shells. When git commits, it asks the Mac's local Secretive for a signature, and Secretive pops a Touch ID prompt on a laptop that may well have its lid closed, in a room I'm not in. My iPad can show me the prompt. It can't press a fingerprint through the glass.
 
-**SSH.** SSH has agent forwarding, which is *almost* the answer. With `ForwardAgent yes`, my client device's SSH agent — Secretive on the cheap MacBook, Blink's Secure Enclave-backed keys on the iPad — becomes reachable on the main Mac through a socket that sshd creates. Signature requests travel back over the SSH connection to the device in my hands, which is exactly what I want.
+**SSH**: SSH has agent forwarding, which is almost the answer. With `ForwardAgent yes`, my client device's SSH agent (Secretive on the cheap MacBook, Blink's Secure Enclave keys on the iPad) becomes reachable on the main Mac through a socket that sshd creates. Signature requests travel back over the SSH connection to the device in my hands. That's exactly what I want.
 
 But naive agent forwarding has three gaps:
 
-1. **The socket is per-session and mortal.** sshd puts it at a random path, exports it as `SSH_AUTH_SOCK` in that one session, and deletes it when the connection drops. Every other shell on the machine has no idea it exists.
+1. **The socket dies with the session.** sshd puts it at a random path, exports it as `SSH_AUTH_SOCK` in that one session, and deletes it when the connection drops. Every other shell on the machine has no idea it exists.
 2. **Long-lived processes never see it.** A Claude Code session started this morning inherited whatever `SSH_AUTH_SOCK` existed this morning. It's not going to re-read my zshrc because I SSHed in after lunch. Neither is the shell inside the Jump Desktop screen share.
-3. **Git needs to know *which key* to ask for.** SSH signing isn't "sign with whatever the agent has" — git needs the specific public key. When I'm remote, the right key is the *client device's* key, not the Mac's. A key baked into git config is wrong half the time.
+3. **Git needs to know which key to ask for.** SSH signing requires the specific public key up front. When I'm remote, the right key is the client device's key, not the Mac's. A key baked into git config is wrong half the time.
 
-I went looking for a way to remotely approve the Mac's own Secretive prompts, and there isn't one — Secretive's approval is deliberately local-only, which is the point of it. The answer isn't to weaken the Mac's key. It's to stop using the Mac's key when I'm not at the Mac, and use the key of the device I *am* at.
+I went looking for a way to remotely approve the Mac's own Secretive prompts. There isn't one. Secretive's approval is deliberately local-only, which is kind of the whole point of it. So instead of trying to weaken the Mac's key, I stopped using the Mac's key when I'm not at the Mac. Sign with the key of the device I'm actually touching.
 
-## The trick: one symlink, zero cached state
+## One Symlink, Zero Cached State
 
-The whole system boils down to two decisions:
+The whole system comes down to two decisions:
 
-1. There is exactly **one** stable agent path on the machine: `~/.ssh/agent.sock`, a symlink. Everything — shells, GUI apps, git — points at the symlink, and the symlink points at whichever real agent socket is currently alive.
-2. Git resolves the signing key **at the moment of signing**, not ahead of time. No cached key file, nothing to go stale.
+1. There is exactly one stable agent path on the machine: `~/.ssh/agent.sock`, a symlink. Shells, GUI apps, and git all point at the symlink, and the symlink points at whichever real agent socket is currently alive.
+2. Git figures out the signing key at the moment of signing, not ahead of time. No cached key file, nothing to go stale.
 
-Everything else is plumbing to maintain those two invariants. Let's walk through the pieces; they all live in [my dotfiles](https://github.com/haacked/dotfiles/).
+Everything else is plumbing to keep those two things true. All of it lives in [my dotfiles](https://github.com/haacked/dotfiles/).
 
-### The symlink healer
+### The Symlink Healer
 
-A small script, [`bin/ssh-agent-sync`](https://github.com/haacked/dotfiles/blob/main/bin/ssh-agent-sync), is the single source of truth for where the symlink points. Handed a live forwarded socket, it points the symlink there; otherwise, if the symlink is dangling, it heals back toward the local Secretive socket:
+A small script, [`bin/ssh-agent-sync`](https://github.com/haacked/dotfiles/blob/main/bin/ssh-agent-sync), decides where the symlink points. Handed a live forwarded socket, it points the symlink there. Otherwise, if the symlink is dangling, it heals back to the local Secretive socket:
 
 ```bash
 sock="$HOME/.ssh/agent.sock"
@@ -106,11 +106,11 @@ else
 fi
 ```
 
-It's idempotent — it only touches the symlink when it isn't already pointing at the right target — and it reports which mode it resolved to (`local`, `forwarded`, or `none`) so callers don't have to re-derive that.
+It's idempotent. It only touches the symlink when the symlink is wrong, and it reports which mode it resolved to (`local`, `forwarded`, or `none`) so callers don't have to figure that out themselves.
 
-### The shell hook
+### The Shell Hook
 
-My zshrc captures the forwarded socket and keeps the symlink synced. The subtle bits are *when* it captures and *how often* it syncs:
+My zshrc captures the forwarded socket and keeps the symlink synced. The subtle bits are when it captures and how often it syncs:
 
 ```sh
 # Capture the sshd-provided socket once, at startup, before the first
@@ -126,22 +126,22 @@ autoload -Uz add-zsh-hook
 add-zsh-hook precmd _ssh_agent_sync
 ```
 
-The forwarded socket path has to be captured *before* the first sync, because after that `SSH_AUTH_SOCK` is the symlink — re-deriving "the forwarded socket" from it later would just compare the symlink against itself.
+The forwarded socket path has to be captured before the first sync. After that, `SSH_AUTH_SOCK` is the symlink, and re-deriving the forwarded socket from it would just compare the symlink against itself.
 
-And it re-syncs on every `precmd` — before each prompt — not just at shell startup. The symlink is shared machine-wide, so a local shell that was already running before my SSH session started will never source zshrc again when that session *ends*. Without the recheck, it would keep pointing at a forwarding socket sshd already tore down. Since `ssh-agent-sync` is idempotent, idle prompts don't pay for a redundant `ln`.
+It also re-syncs on every `precmd`, not just at shell startup. The symlink is shared machine-wide, and a local shell that was running before my SSH session started will never source zshrc again when that session ends. Without the recheck, that shell would keep pointing at a forwarding socket sshd already tore down. Since the healer is idempotent, idle prompts don't pay for a redundant `ln`.
 
-Note what every shell exports: the *symlink*, never the raw socket. That's the indirection that makes long-lived sessions work. A Claude Code session started hours ago holds a path that never changes; what's on the other end of it does.
+Notice that every shell exports the symlink, never the raw socket. That's the indirection that makes long-lived sessions work. A Claude Code session started hours ago holds a path that never changes. What's on the other end of it does.
 
-### Resolving the key at sign time
+### Resolving the Key at Sign Time
 
-Here's where `localSigningKey` vs `signingkey` pays off. Git has an escape hatch: if `user.signingkey` is *unset*, git runs `gpg.ssh.defaultKeyCommand` to ask which key to use, fresh, on every signature:
+Here's where `localSigningKey` pays off. Git has an escape hatch: if `user.signingkey` is unset, git runs `gpg.ssh.defaultKeyCommand` to ask which key to use, fresh, on every signature:
 
 ```ini
 [gpg "ssh"]
     defaultKeyCommand = ~/.dotfiles/bin/git-signing-key
 ```
 
-[`bin/git-signing-key`](https://github.com/haacked/dotfiles/blob/main/bin/git-signing-key) re-runs the healer, then answers based on what the symlink currently resolves to:
+[`bin/git-signing-key`](https://github.com/haacked/dotfiles/blob/main/bin/git-signing-key) re-runs the healer, then answers based on what the symlink currently points to:
 
 ```bash
 mode=$("$bin_dir/ssh-agent-sync") || mode="none"
@@ -161,13 +161,13 @@ if [[ -n "$local_signing_key" && -f "$local_signing_key" ]]; then
 fi
 ```
 
-If a forwarded agent is live, sign with whatever key it offers — that's the client device's Secure Enclave key. Otherwise, fall back to this machine's own Secretive key via `user.localSigningKey`. Since the decision happens at signing time, there's no cached state to go stale: whichever agent is alive when git signs is the one that gets asked.
+If a forwarded agent is live, sign with whatever key it offers. That's the client device's Secure Enclave key. Otherwise, fall back to this machine's own Secretive key via `user.localSigningKey`. Whichever agent is alive when git signs is the one that gets asked.
 
-An earlier version of this setup cached the resolved key in a file that shell hooks kept up to date. It had a structural hole — anything that signed without a shell prompt having been drawn since the last agent transition (a background agent session, a GUI git client) would sign with a stale key or fail. Deleting the cache and resolving at use time made a whole category of bugs impossible.
+An earlier version of this setup cached the resolved key in a file that shell hooks kept up to date. That had a hole in it. Anything that signed without a shell prompt having been drawn since the last agent change (a background agent session, a GUI git client) would sign with a stale key or fail. Deleting the cache and resolving at use time made that whole category of bugs impossible.
 
-### GUI apps and everything that never sources zshrc
+### GUI Apps
 
-One LaunchAgent seeds the environment for everything else at login:
+One LaunchAgent seeds the environment for everything that never sources zshrc:
 
 ```xml
 <key>ProgramArguments</key>
@@ -180,9 +180,9 @@ One LaunchAgent seeds the environment for everything else at login:
 <true/>
 ```
 
-`launchctl setenv` makes `SSH_AUTH_SOCK` visible to GUI apps and anything else that never runs my shell startup — and because it's set to the symlink, not a raw socket, those apps track agent transitions too, without ever knowing transitions happen.
+`launchctl setenv` makes `SSH_AUTH_SOCK` visible to GUI apps. And because it's set to the symlink rather than a raw socket, those apps track agent transitions too, without ever knowing transitions happen.
 
-### The SSH client side
+### The SSH Client Side
 
 The last piece is the client config, which is refreshingly boring:
 
@@ -195,33 +195,33 @@ Host *
     IdentityAgent "~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
 ```
 
-The IP is a [Tailscale](https://tailscale.com/) address, so `ssh macbook` works from anywhere without exposing sshd to the internet. `ForwardAgent yes` does the forwarding; `IdentityAgent` points outbound SSH at Secretive so the *authentication* to the Mac is also enclave-backed. On the iPad, Blink Shell does the equivalent: its keys are Secure Enclave-backed with biometric unlock, and it forwards its agent.
+The IP is a [Tailscale](https://tailscale.com/) address, so `ssh macbook` works from anywhere without exposing sshd to the internet. `ForwardAgent yes` does the forwarding. `IdentityAgent` points outbound SSH at Secretive, so authenticating to the Mac is enclave-backed too. On the iPad, Blink Shell does the equivalent with its own Secure Enclave keys.
 
-## What it looks like in practice
+## What It Looks Like in Practice
 
-From the iPad or the cheap MacBook: `ssh macbook`. Tmux auto-attaches to my persistent session, and — this is the part I love — from that moment, *the entire machine* is signing through the device in my hands. The SSH session, sure. But also the Jump Desktop screen share I have open next to it, and the Claude Code session that's been grinding away since breakfast. They all hold the same symlink, and the symlink now points at the forwarded agent.
+From the iPad or the cheap MacBook: `ssh macbook`. Tmux auto-attaches to my persistent session, and from that moment the entire machine signs through the device in my hands. The SSH session, sure. But also the Jump Desktop screen share I have open next to it, and the Claude Code session that's been grinding away since breakfast. They all hold the same symlink, and the symlink now points at the forwarded agent.
 
-When any of them commits, the approval prompt appears right here: Touch ID on the MacBook Neo, Face ID via Blink on the iPad. I approve it from the couch. The commit is signed by *this* device's Secure Enclave key — a different key than the main Mac would use, but `allowed_signers` and GitHub both know all my keys, so every commit verifies the same.
+When any of them commits, the approval prompt appears right here. Touch ID on the cheap MacBook. Face ID via Blink on the iPad. The commit gets signed with this device's key, which is a different key than the main Mac would use, but `allowed_signers` and GitHub know all my keys, so every commit verifies the same.
 
-When I close the connection, the next shell prompt on the Mac notices the dead socket and heals the symlink back to local Secretive. Sit down at the desk, and Touch ID works like nothing ever happened. No mode switch, no config to flip. The system doesn't have a "remote mode" — it just has a symlink that always points at the truth.
+When I close the connection, the next shell prompt on the Mac notices the dead socket and heals the symlink back to local Secretive. I sit down at the desk and Touch ID works like nothing happened. There's no remote mode to toggle. Just a symlink that points at whatever agent is real right now.
 
 ## Caveats
 
-**Agent forwarding is a trust decision.** A forwarded agent means root (and you) on the host can send signature requests to your client's agent. Forwarding into a box you don't control is how people get their keys borrowed. Here I'm forwarding into my own Mac over my own tailnet, and every request still requires biometric approval on the client, so I sleep fine — but I wouldn't `ForwardAgent yes` to a shared server.
+**Agent forwarding is a trust decision.** A forwarded agent means anyone with root on the host can send signature requests to your client's agent. Forwarding into a box you don't control is how people get their keys borrowed. I'm forwarding into my own Mac over my own tailnet, and every request still requires biometric approval on the client, so I sleep fine. I wouldn't `ForwardAgent yes` to a shared server.
 
-**Pure screen share can't sign unattended.** If there's no live SSH connection, the symlink points at the Mac's local Secretive, and that still wants a human at the machine. Usually the fix is one `ssh macbook` from whatever device I'm holding. For the rare case where even that's not an option, the escape hatch is `git commit --no-gpg-sign` now and a batch re-sign later:
+**Pure screen share can't sign unattended.** If there's no live SSH connection, the symlink points at the Mac's local Secretive, and that still wants a human at the machine. Usually the fix is one `ssh macbook` from whatever device I'm holding. For the rare case where even that's not an option, I commit with `--no-gpg-sign` and batch re-sign later:
 
 ```ini
 [alias]
     sign-unpushed = "!f() { DEFAULT=$(git default); UPSTREAM=${1-origin/$DEFAULT}; git rebase --exec \"git commit --amend --no-edit -S\" $UPSTREAM; }; f"
 ```
 
-`git sign-unpushed` rebases the unpushed commits, re-signing each one — a satisfying little drumroll of Touch ID prompts when I'm back at the desk.
+`git sign-unpushed` rebases the unpushed commits and re-signs each one. Back at the desk, it's a satisfying little drumroll of Touch ID prompts.
 
-## Wrap up
+## Steal It
 
-The security posture here is the part I'd underline: at no point does any private key exist as a file, on any machine, ever. Each device has its own key sealed in its own Secure Enclave, every signature requires a biometric approval on a device in my physical possession, and losing any single device revokes exactly one key.
+At no point in any of this does a private key exist as a file. Each device has its own key sealed in its own Secure Enclave. Every signature requires a biometric approval on a device I'm physically touching. Losing a device revokes exactly one key.
 
-And the ergonomics didn't pay for it. Claude Code works on the big machine; I supervise from whatever slab of glass is nearby; commits come out signed and verified. The whole thing is a couple of small scripts, a symlink, and one underappreciated git config setting.
+And I didn't give up anything to get here. Claude Code works on the big machine, I supervise from whatever screen is nearby, and commits come out signed and verified. The whole thing is two small scripts, a symlink, and one underappreciated git config setting.
 
-Everything is in my [dotfiles repo](https://github.com/haacked/dotfiles/) — `bin/ssh-agent-sync`, `bin/git-signing-key`, the zshrc hook, and the LaunchAgent — if you want to steal it. That's what dotfiles are for.
+Everything is in my [dotfiles repo](https://github.com/haacked/dotfiles/): `bin/ssh-agent-sync`, `bin/git-signing-key`, the zshrc hook, and the LaunchAgent. That's what dotfiles are for.

--- a/_posts/2026/2026-07-20-remote-commit-signing.md
+++ b/_posts/2026/2026-07-20-remote-commit-signing.md
@@ -24,9 +24,9 @@ Secretive generates keys inside the Secure Enclave, the same hardware chip that 
 That changes the threat model. Malware can't steal a key it can't read. The best it can do is request a signature, and an unexpected approval prompt is a pretty good alarm bell. A stolen laptop yields nothing usable. And since each machine's key lives and dies in that machine's enclave, revoking the key for a laptop I sold is a one-line change instead of a fire drill.
 
 > [!IMPORTANT]
-> That alarm bell only rings if you check "Requires Authentication" when you create the key in Secretive. You can't change it later, only create a new key. Without it, the enclave signs silently for any process running as you, which quietly deletes most of the benefit described above. Relatedly, when Secretive prompts you, it offers to persist the approval for a period of time. During that window, signing is silent too. Keep it short.
+> That alarm bell only rings if you check "Requires Authentication" when you create the key in Secretive. You can't change it later, only create a new key. Without it, the enclave signs silently for any process running as you, which defeats most of the point. And when Secretive prompts you, it offers to keep the approval active for a period of time. During that window, signing is silent too. Keep it short.
 
-The tradeoff is the same as the feature: the key can't leave the machine. Which brings us back to my problem.
+The tradeoff, of course, is that the key can't leave the machine even when I have a good reason to want it to. Which brings us back to my problem.
 
 ## The Setup
 
@@ -64,7 +64,7 @@ So far, so standard. Sitting at any one of these machines, `git commit` triggers
 
 When I remote into the main Mac, there are two ways in, and both break signing in their own way.
 
-**Screen sharing (Jump Desktop)**: I'm looking at the Mac's actual desktop, driving its actual shells. When git commits, it asks the Mac's local Secretive for a signature, and Secretive pops a Touch ID prompt on a laptop that may well have its lid closed, in a room I'm not in. My iPad can show me the prompt. It can't press a fingerprint through the glass, no matter how hard I tap it.
+**Screen sharing (Jump Desktop)**: I'm looking at the Mac's actual desktop, driving its actual shells. When git commits, it asks the Mac's local Secretive for a signature, and Secretive pops a Touch ID prompt on a laptop that probably has its lid closed, in a room I'm not in. My iPad can show me the prompt. It can't press a fingerprint through the glass, no matter how hard I tap it.
 
 **SSH**: SSH has agent forwarding, which is almost the answer. With `ForwardAgent yes`, my client device's SSH agent (Secretive on the cheap MacBook, Blink's Secure Enclave keys on the iPad) becomes reachable on the main Mac through a socket that sshd creates. Signature requests travel back over the SSH connection to the device in my hands, which is exactly what I want.
 
@@ -133,7 +133,7 @@ The forwarded socket path has to be captured before the first sync. After that, 
 
 It also re-syncs on every `precmd`, not just at shell startup. The symlink is shared machine-wide, and a local shell that was running before my SSH session started will never source zshrc again when that session ends. Without the recheck, that shell would keep pointing at a forwarding socket sshd already tore down. Since the healer is idempotent, idle prompts don't pay for a redundant `ln`.
 
-Notice that every shell exports the symlink, never the raw socket. That's the indirection that makes long-lived sessions work. A Claude Code session started hours ago holds a path that never changes, even though what's on the other end of it comes and goes.
+Every shell exports the symlink, never the raw socket. That's the indirection that makes long-lived sessions work. A Claude Code session started hours ago holds a path that never changes, even though what's on the other end of it comes and goes.
 
 ### Resolving the Key at Sign Time
 
@@ -166,7 +166,7 @@ fi
 
 If a forwarded agent is live, sign with whatever key it offers. That's the client device's Secure Enclave key. Otherwise, fall back to this machine's own Secretive key via `user.localSigningKey`. Whichever agent is alive when git signs is the one that gets asked.
 
-An earlier version of this setup cached the resolved key in a file that shell hooks kept up to date. That had a hole in it. Anything that signed without a shell prompt having been drawn since the last agent change (a background agent session, a GUI git client) would sign with a stale key or fail. Deleting the cache and resolving at use time made that whole category of bugs impossible.
+An earlier version of this setup cached the resolved key in a file that shell hooks kept up to date. That had a hole in it. Anything that signed without a shell prompt having been drawn since the last agent change (a background agent session, a GUI git client) would sign with a stale key or fail. Deleting the cache and resolving at use time made that whole category of bugs go away.
 
 ### GUI Apps
 
@@ -204,7 +204,7 @@ The IP is a [Tailscale](https://tailscale.com/) address, so `ssh macbook` works 
 
 From the iPad or the cheap MacBook: `ssh macbook`. Tmux auto-attaches to my persistent session, and from that moment the entire machine signs through the device in my hands. The SSH session, sure. But also the Jump Desktop screen share I have open next to it, and the Claude Code session that's been grinding away since breakfast. They all hold the same symlink, and the symlink now points at the forwarded agent.
 
-When any of them commits, the approval prompt appears right here. Touch ID on the MacBook Neo. Face ID via Blink on the iPad. The commit gets signed with this device's key, which is a different key than the main Mac would use, but `allowed_signers` and GitHub know all my keys, so every commit verifies the same.
+When any of them commits, the approval prompt appears right here. A double-click on my Apple Watch for the MacBook Neo. Face ID via Blink on the iPad. The commit gets signed with this device's key, which is a different key than the main Mac would use, but `allowed_signers` and GitHub know all my keys, so every commit verifies the same.
 
 When I close the connection, the next shell prompt on the Mac notices the dead socket and heals the symlink back to local Secretive. I sit down at the desk and Touch ID works like nothing happened. There's no remote mode to toggle, just a symlink that points at whatever agent is currently real.
 
@@ -233,7 +233,7 @@ The fix has two parts, both in the dotfiles now. The SSH config disables agent f
 
 ## Steal It
 
-At no point in any of this does a private key exist as a file. Each device has its own key sealed in its own Secure Enclave. Every signature requires a biometric approval on a device I'm physically touching. Losing a device revokes exactly one key.
+At no point in any of this does a private key exist as a file. Each device has its own key sealed in its own Secure Enclave, and every signature requires a biometric approval on a device I'm physically touching. If I lose a device, I revoke one key and move on.
 
 And I didn't give up anything to get here. Claude Code works on the big machine, I supervise from whatever screen is nearby, and commits come out signed and verified. The whole thing is two small scripts, a symlink, and one underappreciated git config setting. The symlink is doing most of the work, which feels right for a technology from 1983.
 

--- a/_posts/2026/2026-07-20-remote-commit-signing.md
+++ b/_posts/2026/2026-07-20-remote-commit-signing.md
@@ -2,7 +2,7 @@
 title: "Sign Commits from Anywhere Without Your Keys Going Anywhere"
 description: "How I sign git commits with Secure Enclave keys while remoted into my main Mac from an iPad or a cheap laptop. All it takes is Secretive, SSH agent forwarding, and one well-placed symlink."
 tags: [git, security, ssh, productivity, dotfiles]
-excerpt_image: ""
+excerpt_image: "https://i.haacked.com/blog/2026-07-20-remote-commit-signing/image1.png"
 ---
 
 These days, my main MacBook Pro does most of its coding without me. I mostly show up for the credit. For example, every day I walk with my daughter to a coffee shop while Claude Code churns through tasks in [worktrees](https://haacked.com/archive/2025/11/21/tree-me/). At the coffee shop, I'll remote in on a cheap MacBook Neo (upgraded from an iPad) to continue working. It's pretty much just a remote control for my main MacBook. [Jump Desktop](https://jumpdesktop.com/) gives me a screen share, [Blink Shell](https://blink.sh/) gives me a terminal on the iPad, and the work keeps going whether I'm there or not.
@@ -11,7 +11,7 @@ There was one snag: signed commits.
 
 I sign all my commits, and my signing keys live in [the Secure Enclave](https://support.apple.com/guide/security/the-secure-enclave-sec59b0b31ff/web) via [Secretive](https://github.com/maxgoedjen/secretive). That's great for security. The key physically cannot leave the machine. It's less great when git asks the Secure Enclave to sign a commit and the Secure Enclave asks for a Touch ID press from a person who is forty miles away from the keyboard.
 
-[image1: A person relaxing on a couch with an iPad, remotely controlling a MacBook on a desk in another room. A glowing padlock hovers over the MacBook. Cozy, slightly whimsical illustration style.]
+![Illustration of someone coding at a coffee shop, remotely connected via a glowing padlock icon to a Mac sitting on a desk back home.](https://i.haacked.com/blog/2026-07-20-remote-commit-signing/image1.png)
 
 This post walks through the setup I landed on. I can be on my iPad or the cheap laptop, remote into the main Mac, and every commit gets signed by a hardware-backed key. Even commits made by a Claude Code session that's been running since morning. The approval prompt shows up on the device in my hands.
 

--- a/_posts/2026/2026-07-20-remote-commit-signing.md
+++ b/_posts/2026/2026-07-20-remote-commit-signing.md
@@ -64,7 +64,7 @@ So far, so standard. Sitting at any one of these machines, `git commit` triggers
 
 When I remote into the main Mac, there are two ways in, and both break signing in their own way.
 
-**Screen sharing (Jump Desktop)**: I'm looking at the Mac's actual desktop, driving its actual shells. When git commits, it asks the Mac's local Secretive for a signature, and Secretive pops a Touch ID prompt on a laptop that probably has its lid closed, in a room I'm not in. My iPad can show me the prompt. It can't press a fingerprint through the glass, no matter how hard I tap it.
+**Screen sharing (Jump Desktop)**: I'm looking at the Mac's actual desktop, driving its actual shells. When git commits, it asks the Mac's local Secretive for a signature, and Secretive pops a Touch ID prompt on a laptop sitting alone at a desk in a room I'm not in, its screen long asleep. My iPad can show me the prompt. It can't press a fingerprint through the glass, no matter how hard I tap it.
 
 **SSH**: SSH has agent forwarding, which is almost the answer. With `ForwardAgent yes`, my client device's SSH agent (Secretive on the cheap MacBook, Blink's Secure Enclave keys on the iPad) becomes reachable on the main Mac through a socket that sshd creates. Signature requests travel back over the SSH connection to the device in my hands, which is exactly what I want.
 

--- a/script/generate-images
+++ b/script/generate-images
@@ -38,22 +38,40 @@ extract_placeholder_description() {
 generate_dalle_image() {
   local prompt="$1"
   local style="${2:-${DALLE_STYLE:-vivid}}"
+  local model="${DALLE_MODEL:-gpt-image-1}"
 
+  # The 'style' parameter (vivid/natural) only exists on the retired
+  # dall-e-3 endpoint. gpt-image-1 and dall-e-2 reject unknown params.
   local payload
-  payload=$(jq -n \
-    --arg model "${DALLE_MODEL:-dall-e-3}" \
-    --arg prompt "$prompt" \
-    --arg size "${DALLE_SIZE:-1024x1024}" \
-    --arg quality "${DALLE_QUALITY:-standard}" \
-    --arg style "$style" \
-    '{
-      model: $model,
-      prompt: $prompt,
-      n: 1,
-      size: $size,
-      quality: $quality,
-      style: $style
-    }')
+  if [[ "$model" == "dall-e-3" ]]; then
+    payload=$(jq -n \
+      --arg model "$model" \
+      --arg prompt "$prompt" \
+      --arg size "${DALLE_SIZE:-1024x1024}" \
+      --arg quality "${DALLE_QUALITY:-standard}" \
+      --arg style "$style" \
+      '{
+        model: $model,
+        prompt: $prompt,
+        n: 1,
+        size: $size,
+        quality: $quality,
+        style: $style
+      }')
+  else
+    payload=$(jq -n \
+      --arg model "$model" \
+      --arg prompt "$prompt" \
+      --arg size "${DALLE_SIZE:-1024x1024}" \
+      --arg quality "${DALLE_QUALITY:-high}" \
+      '{
+        model: $model,
+        prompt: $prompt,
+        n: 1,
+        size: $size,
+        quality: $quality
+      }')
+  fi
 
   # Use curl config to hide API key from process list
   local curl_config
@@ -83,27 +101,30 @@ EOF
     return 1
   fi
 
-  # Validate response contains expected data
-  if ! echo "$response" | jq -e '.data[0].url' > /dev/null 2>&1; then
+  # dall-e-3/dall-e-2 return a downloadable url; gpt-image-1 only ever
+  # returns base64 image data. Support whichever the response contains.
+  if echo "$response" | jq -e '.data[0].url' > /dev/null 2>&1; then
+    local image_url
+    image_url=$(echo "$response" | jq -r '.data[0].url')
+
+    # Validate URL is from OpenAI blob storage domain
+    # OpenAI DALL-E images are served from Azure blob storage
+    if [[ ! "$image_url" =~ ^https://oaidalleapiprodscus\.blob\.core\.windows\.net/ ]]; then
+      echo "Error: Image URL is not from expected OpenAI blob storage domain: $image_url" >&2
+      return 1
+    fi
+
+    echo "$image_url"
+  elif echo "$response" | jq -e '.data[0].b64_json' > /dev/null 2>&1; then
+    echo "$response" | jq -r '.data[0].b64_json'
+  else
     echo "Error: Unexpected response from OpenAI API" >&2
     return 1
   fi
-
-  local image_url
-  image_url=$(echo "$response" | jq -r '.data[0].url')
-
-  # Validate URL is from OpenAI blob storage domain
-  # OpenAI DALL-E images are served from Azure blob storage
-  if [[ ! "$image_url" =~ ^https://oaidalleapiprodscus\.blob\.core\.windows\.net/ ]]; then
-    echo "Error: Image URL is not from expected OpenAI blob storage domain: $image_url" >&2
-    return 1
-  fi
-
-  echo "$image_url"
 }
 
 download_image() {
-  local url="$1"
+  local data="$1"
   local output_path="$2"
 
   # Validate output path is safe
@@ -112,10 +133,18 @@ download_image() {
     return 1
   fi
 
-  # Download image
-  if ! curl -s -f -o "$safe_path" "$url"; then
-    echo "Error: Failed to download image from $url" >&2
-    return 1
+  # generate_dalle_image() returns either a downloadable URL (dall-e-2/3)
+  # or raw base64 image data (gpt-image-1, which has no url response mode).
+  if [[ "$data" =~ ^https?:// ]]; then
+    if ! curl -s -f -o "$safe_path" "$data"; then
+      echo "Error: Failed to download image from $data" >&2
+      return 1
+    fi
+  else
+    if ! echo "$data" | base64 -d > "$safe_path" 2>/dev/null; then
+      echo "Error: Failed to decode base64 image data" >&2
+      return 1
+    fi
   fi
 
   # Validate downloaded file is an image


### PR DESCRIPTION
New post walking through my setup for signing git commits with Secure Enclave keys (via Secretive) while remoted into my main Mac from a cheaper laptop or iPad. Covers why hardware-backed keys beat key files, the one-symlink/sign-at-use-time architecture in my dotfiles, the self-SSH loop that bit me, and the caveats (including requiring authentication on the signing key).

Planned publish date: Monday, 2026-07-20 (post is dated accordingly).

Images are generated and published to the CDN. The illustration commit and a small `gpt-image-1` support change to the image workflow (`6a0ef352`) ride along on this branch.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*